### PR TITLE
🧹 [Code Health] Replace Debug.Write with Logger.Debug for consistency

### DIFF
--- a/HDLG winforms/MainWindow.cs
+++ b/HDLG winforms/MainWindow.cs
@@ -278,7 +278,7 @@ toolStripStatusLabelTotalTime.Visible = false;
 
         private PerformanceCount PerformDirectoryBrowseHtml(string selecteDirectory, string saveFilePath)
         {
-            Debug.Write($"{nameof(PerformDirectoryBrowseHtml)} started at {DateTime.Now:T}");
+            Logger.Debug($"{nameof(PerformDirectoryBrowseHtml)} started at {DateTime.Now:T}");
             TimeSpan saveTime = TimeSpan.Zero;
             TimeSpan browseTime = TimeSpan.Zero;
             if (!string.IsNullOrWhiteSpace(selecteDirectory))
@@ -325,7 +325,7 @@ toolStripStatusLabelTotalTime.Visible = false;
 
         private void BackgroundWorkerDirectoryBrowseHtml_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
-            Debug.Write($"Completed at {DateTime.Now.ToLongTimeString()}");
+            Logger.Debug($"Completed at {DateTime.Now.ToLongTimeString()}");
             UseWaitCursor = false;
             btnStartXml.Enabled = true;
             btnStartHtml.Enabled = true;


### PR DESCRIPTION
🎯 What: Replaced inconsistent Debug.Write statements with Logger.Debug in `HDLG winforms/MainWindow.cs`.
💡 Why: Ensures consistent logging across the application using Serilog, improving log aggregatability, code readability, and maintainability.
✅ Verification: Built successfully with `dotnet build`. Tests could not be run locally on Linux because of missing Windows desktop app framework dependencies, but this logging-only change poses minimal risk of breaking actual logic.
✨ Result: `PerformDirectoryBrowseHtml` and `BackgroundWorkerDirectoryBrowseHtml_RunWorkerCompleted` now use unified Serilog logging, matching the rest of the file (like `PerformDirectoryBrowseXml`).

---
*PR created automatically by Jules for task [11463118655433323580](https://jules.google.com/task/11463118655433323580) started by @bestter*