### PR TITLE
⚡ Bolt: Optimize HdlgFile initialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - FileInfo instantiation in hot loops is a performance bottleneck
 **Learning:** Using `new FileInfo(path).Extension.ToUpperInvariant()` to check file extensions inside a hot loop (like checking every file in a directory) causes significant unnecessary allocations and CPU overhead compared to static string operations.
 **Action:** When filtering or checking paths, avoid `FileInfo` allocations. Prefer static helper methods like `Path.GetExtension(path)` and fast string operations like `path.EndsWith(..., StringComparison.OrdinalIgnoreCase)`.
+
+## 2025-02-14 - FileInfo Allocation Redundancy
+**Learning:** During directory enumeration using `DirectoryInfo.EnumerateFiles()`, creating a new `FileInfo` from the generated file's `FullName` inside the `HdlgFile` class is redundant and causes extra allocations and potential duplicate file system trips.
+**Action:** Always reuse the existing `FileInfo` object yielded by `EnumerateFiles()` instead of instantiating new wrappers via path string constructors, particularly in tight inner loops iterating over many files.

--- a/HDLG winforms/HdlgDirectory.cs
+++ b/HDLG winforms/HdlgDirectory.cs
@@ -82,7 +82,7 @@ namespace HDLG_winforms
             foreach (var f in directoryInfo.EnumerateFiles())
             {
                 var properties = propertyBrowser.GetFileProperty(f.FullName);
-                var file = new HdlgFile(f.FullName, properties);
+                var file = new HdlgFile(f, properties);
                 files.Add(file);
             }
             files.Sort();

--- a/HDLG winforms/HdlgFile.cs
+++ b/HDLG winforms/HdlgFile.cs
@@ -24,11 +24,15 @@ namespace HDLG_winforms
         public IReadOnlyDictionary<string, IConvertible> Properties { get; }
 
         public HdlgFile(string path, Dictionary<string, IConvertible>? properties)
+            : this(new FileInfo(path ?? throw new ArgumentNullException(nameof(path))), properties)
         {
-            ArgumentNullException.ThrowIfNull(path);
+        }
 
-            Path = path;
-            FileInfo info = new(Path);
+        public HdlgFile(FileInfo info, Dictionary<string, IConvertible>? properties)
+        {
+            ArgumentNullException.ThrowIfNull(info);
+
+            Path = info.FullName;
 
             if (info.Exists)
             {


### PR DESCRIPTION
💡 What: Overload the `HdlgFile` constructor to accept a `FileInfo` directly, and update `HdlgDirectory.Browse` to pass the yielded `FileInfo` instead of the `FullName` string.
🎯 Why: Inside `HdlgDirectory.cs`, `DirectoryInfo.EnumerateFiles()` already yields `FileInfo` objects, but the `HdlgFile` constructor was taking the `FullName` string and creating a brand new `FileInfo` object from it, resulting in redundant memory allocations and unnecessary internal file system checks in a potentially hot inner loop.
📊 Impact: Reduces memory allocations and avoids redundant filesystem calls when scanning large directories with thousands of files.
🔬 Measurement: Can be verified by running the application against a large directory and monitoring memory allocations and file system access with a profiler like dotTrace or PerfView. Tests and build check pass.

---
*PR created automatically by Jules for task [14353926985177069917](https://jules.google.com/task/14353926985177069917) started by @bestter*