### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in HTML export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-23 - [XSS in HTML Export]
+**Vulnerability:** Found an XSS vulnerability where user-controlled metadata like file names, directory names, and file properties were directly written to HTML report via string interpolation in DirectoryBrowser.cs.
+**Learning:** System directories and files can contain arbitrary characters, and metadata parsers extract tags that can be manipulated by an attacker to execute JS when the generated HTML is viewed.
+**Prevention:** Always use WebUtility.HtmlEncode (and WebUtility.UrlEncode for href attributes) to sanitize user-controlled strings when manually generating HTML outputs.

--- a/HDLG winforms/DirectoryBrowser.cs
+++ b/HDLG winforms/DirectoryBrowser.cs
@@ -9,6 +9,7 @@ You should have received a copy of the GNU General Public License along with Foo
  */
 using Serilog;
 using System.Globalization;
+using System.Net;
 using System.Text;
 using System.Xml;
 
@@ -254,6 +255,7 @@ namespace HDLG_winforms
 			using FileStream fileStream = new( fileInfo.FullName, FileMode.Create, FileAccess.Write, FileShare.None );
 			using StreamWriter sw = new( fileStream, encoding, 4096, false );
 			var title = $"HTML Directory list generator  {version} {directory.Path} {DateTimeOffset.Now.ToString( "F", CultureInfo.CurrentCulture )}";
+			var encodedTitle = WebUtility.HtmlEncode(title);
 			await sw.WriteLineAsync( "<!DOCTYPE html>" ).ConfigureAwait( false );
 
 			await sw.WriteLineAsync( $"<html lang=\"{CultureInfo.CurrentCulture.TwoLetterISOLanguageName}\">" ).ConfigureAwait( false );
@@ -262,7 +264,7 @@ namespace HDLG_winforms
 			await sw.WriteLineAsync( "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "<meta name=\"robots\" content=\"noindex, nofollow\">" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "<meta name=\"rating\" content=\"general\">" ).ConfigureAwait( false );
-			await sw.WriteAsync( $"<title>{title}</title>" ).ConfigureAwait( false );
+			await sw.WriteAsync( $"<title>{encodedTitle}</title>" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( GetGoogleFontHeader( ) ).ConfigureAwait( false );
 			await sw.WriteLineAsync( await GetCssAsync( ).ConfigureAwait( false ) ).ConfigureAwait( false );
 			await sw.WriteLineAsync( ).ConfigureAwait( false );
@@ -273,7 +275,7 @@ namespace HDLG_winforms
 			await sw.WriteLineAsync( "<div class=\"Hdlg\">" ).ConfigureAwait( false );
 
 			await sw.WriteLineAsync( "<div class=\"version\">" ).ConfigureAwait( false );
-			await sw.WriteLineAsync( $"<h1>{title}</h1>" ).ConfigureAwait( false );
+			await sw.WriteLineAsync( $"<h1>{encodedTitle}</h1>" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "<span>Version</span>" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( $"<span>{version}</span>" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "</div>" ).ConfigureAwait( false );
@@ -282,7 +284,7 @@ namespace HDLG_winforms
 
 			await sw.WriteLineAsync( "<div class=\"directoryHeader\">" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "<span>Directory</span>" ).ConfigureAwait( false );
-			await sw.WriteLineAsync( $"<h2>{directory.Path}</h2>" ).ConfigureAwait( false );
+			await sw.WriteLineAsync( $"<h2>{WebUtility.HtmlEncode( directory.Path )}</h2>" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "</div>" ).ConfigureAwait( false );
 
 			await sw.WriteLineAsync( "<div class=\"spacer\">&nbsp;</div>" ).ConfigureAwait( false );
@@ -339,7 +341,7 @@ namespace HDLG_winforms
 		private static async Task WriteDirectoryListContainAsync (TextWriter writer, HdlgDirectory directory, int depth)
 		{
 			string spacer = new string( ' ', depth + 1 );
-			await writer.WriteLineAsync( $"{spacer}<li><a href=\"#{directory.Path}\">{directory.Name}</a></li>" ).ConfigureAwait( false );
+			await writer.WriteLineAsync( $"{spacer}<li><a href=\"#{WebUtility.HtmlEncode( directory.Path )}\">{WebUtility.HtmlEncode( directory.Name )}</a></li>" ).ConfigureAwait( false );
 
 			if (directory.Directories.Count > 0)
 			{
@@ -363,9 +365,9 @@ namespace HDLG_winforms
 			log.Debug( $"In {nameof( WritHtmlDirectoryAsync )} {nameof( HdlgDirectory )} {directory}" );
 			string spacer = new string( ' ', depth );
 
-			await writer.WriteLineAsync( spacer + $"<div class=\"directory\" id=\"{directory.Path}\">" ).ConfigureAwait( false );
-			await writer.WriteLineAsync( $"{spacer}<span class=\"name\">{directory.Name}</span>" ).ConfigureAwait( false );
-			await writer.WriteLineAsync( $"{spacer}<span class=\"path\">{directory.Path}</span>" ).ConfigureAwait( false );
+			await writer.WriteLineAsync( spacer + $"<div class=\"directory\" id=\"{WebUtility.HtmlEncode( directory.Path )}\">" ).ConfigureAwait( false );
+			await writer.WriteLineAsync( $"{spacer}<span class=\"name\">{WebUtility.HtmlEncode( directory.Name )}</span>" ).ConfigureAwait( false );
+			await writer.WriteLineAsync( $"{spacer}<span class=\"path\">{WebUtility.HtmlEncode( directory.Path )}</span>" ).ConfigureAwait( false );
 			await writer.WriteLineAsync( $"{spacer}<span class=\"creationTime\">{directory.CreationTime.ToString( "F", CultureInfo.CurrentCulture )}</span>" ).ConfigureAwait( false );
 
 			await writer.WriteLineAsync( $"{spacer}<a href=\"#directoryList\">⬆️</a>" ).ConfigureAwait( false );
@@ -413,7 +415,7 @@ namespace HDLG_winforms
 			await writer.WriteLineAsync( spacer + "<ul class=\"file\">" ).ConfigureAwait( false );
 
 
-			await writer.WriteLineAsync( $"{spacer}<li><a href=\"file:///{file.Path}\" download=\"{file.Name}\" referrerpolicy=\"strict-origin\">{file.Name}</a></li>" ).ConfigureAwait( false );
+			await writer.WriteLineAsync( $"{spacer}<li><a href=\"file:///{WebUtility.HtmlEncode( file.Path )}\" download=\"{WebUtility.HtmlEncode( file.Name )}\" referrerpolicy=\"strict-origin\">{WebUtility.HtmlEncode( file.Name )}</a></li>" ).ConfigureAwait( false );
 
 
 			await writer.WriteLineAsync( $"{spacer}<li class=\"size\">{file.Size.ToString( CultureInfo.CurrentCulture )} kb</li>" ).ConfigureAwait( false );
@@ -428,7 +430,7 @@ namespace HDLG_winforms
 					if (!string.IsNullOrWhiteSpace( property.Key ) && property.Value != null)
 					{
 						await writer.WriteLineAsync( spacer + "\t<li class=\"extentedProperty\">" ).ConfigureAwait( false );
-						await writer.WriteLineAsync( $"{spacer}\t\t<span>{property.Key}</span>" ).ConfigureAwait( false );
+						await writer.WriteLineAsync( $"{spacer}\t\t<span>{WebUtility.HtmlEncode( property.Key )}</span>" ).ConfigureAwait( false );
 
 						if (property.Value is DateTime dtValue)
 						{
@@ -437,7 +439,7 @@ namespace HDLG_winforms
 						else
 						{
 							var value = property.Value.ToString( CultureInfo.CurrentCulture );
-							await writer.WriteLineAsync( $"{spacer}\t\t<span>{value}</span>" ).ConfigureAwait( false );
+							await writer.WriteLineAsync( $"{spacer}\t\t<span>{WebUtility.HtmlEncode( value )}</span>" ).ConfigureAwait( false );
 						}
 
 						await writer.WriteLineAsync( spacer + "\t</li>" ).ConfigureAwait( false );


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Cross-Site Scripting (XSS) in HTML Export. User-controlled directory names, file names, and file properties were directly concatenated into HTML strings.
🎯 Impact: Maliciously crafted file or directory names could result in arbitrary JavaScript execution when viewing the generated HTML report.
🔧 Fix: Sanitized all user-controlled data written to HTML inside `HDLG winforms/DirectoryBrowser.cs` using `System.Net.WebUtility.HtmlEncode()`.
✅ Verification: Tested against a local codebase with a mock C# console app using `WebUtility.HtmlEncode`. Built the project with `dotnet build -p:EnableWindowsTargeting=true HDLG.sln` to ensure compilation correctness.

---
*PR created automatically by Jules for task [15946726849775885935](https://jules.google.com/task/15946726849775885935) started by @bestter*