### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability in image parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** Found an XSS vulnerability where user-controlled metadata like file names, directory names, and file properties were directly written to HTML report via string interpolation in DirectoryBrowser.cs.
 **Learning:** System directories and files can contain arbitrary characters, and metadata parsers extract tags that can be manipulated by an attacker to execute JS when the generated HTML is viewed.
 **Prevention:** Always use WebUtility.HtmlEncode (and WebUtility.UrlEncode for href attributes) to sanitize user-controlled strings when manually generating HTML outputs.
+
+## 2026-05-23 - [DoS via Unhandled Image Exception]
+**Vulnerability:** Found an issue where unexpected exceptions during image parsing (`Image.Identify`) were re-thrown (`throw;`) instead of being safely caught and logged.
+**Learning:** Re-throwing generic exceptions in background tasks without proper isolation can crash the main application, leading to Denial of Service (DoS) when a user scans a directory containing a maliciously crafted image file that triggers an unexpected exception in `ImageSharp`.
+**Prevention:** Always catch and log generic exceptions when parsing files from untrusted sources, ensuring that a single corrupted or malicious file does not crash the entire application.

--- a/HDLG file property/ImagePropertyGetter.cs
+++ b/HDLG file property/ImagePropertyGetter.cs
@@ -57,10 +57,12 @@ namespace HdlgFileProperty
                 //The image content is corrupted or invalid.
                 Logger?.Warning(e,"Invalid image content for file: {FilePath}", path);
             }
-            catch (Exception)
+#pragma warning disable CA1031 // Ne pas intercepter les types d'exception générale
+            catch (Exception e)
             {
-                throw;
+                Logger?.Warning(e, "Cannot read properties from file: {FilePath}", path);
             }
+#pragma warning restore CA1031 // Ne pas intercepter les types d'exception générale
             return properties;
         }
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unhandled generic exceptions thrown by `ImageSharp` during image parsing (`Image.Identify`) were being re-thrown (`throw;`) directly by the background task, causing unhandled application-level crashes (Denial of Service).
🎯 **Impact:** An attacker could craft a specific malformed or malicious image file and place it in a directory. When the user scans this directory, the application crashes entirely, resulting in Denial of Service and loss of progress.
🔧 **Fix:** Caught generic exceptions in `ImagePropertyGetter.cs`, properly logged them, and allowed the application to gracefully skip the corrupted file and continue parsing the rest of the directory.
✅ **Verification:** Verified by compiling via `dotnet build -p:EnableWindowsTargeting=true`.

Updated the Sentinel journal with these learnings.

---
*PR created automatically by Jules for task [854698887498925660](https://jules.google.com/task/854698887498925660) started by @bestter*