### PR TITLE
⚡ Bolt: Remove redundant string allocation in case-insensitive HashSet lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2025-02-14 - Redundant string allocation in case-insensitive HashSet lookups
 **Learning:** Checking a HashSet that was initialized with `StringComparer.OrdinalIgnoreCase` using an explicitly upper-cased string (`extension.ToUpperInvariant()`) is redundant and causes unnecessary string allocations, which can add up in hot loops like checking supported extensions for every file.
 **Action:** When a collection like `HashSet<string>` is already configured to be case-insensitive, avoid any `.ToUpperInvariant()` or `.ToLowerInvariant()` calls on strings passed to its methods (e.g., `.Contains()`).
+
+## 2026-05-24 - Redundant string allocation with case-insensitive collections
+**Learning:** When using case-insensitive collections like `HashSet<string>(StringComparer.OrdinalIgnoreCase)`, calling `.ToUpperInvariant()` or similar methods on the checked string is redundant and causes unnecessary memory allocations.
+**Action:** Always check the comparer used by a collection before transforming strings for lookup. Avoid string transformations in hot loops like file enumeration.

--- a/HDLG file property/Mp3PropertyGetter.cs
+++ b/HDLG file property/Mp3PropertyGetter.cs
@@ -89,7 +89,9 @@ namespace HdlgFileProperty
         public bool IsSupportedFile(string path)
         {
             var extension = Path.GetExtension(path);
-            return extension != null && _supportedExtensions.Contains(extension.ToUpperInvariant());
+            // Optimization: _supportedExtensions uses StringComparer.OrdinalIgnoreCase,
+            // so ToUpperInvariant() is an unnecessary allocation.
+            return extension != null && _supportedExtensions.Contains(extension);
         }
     }
 }


### PR DESCRIPTION
💡 What: Removed `.ToUpperInvariant()` call when checking against `_supportedExtensions` in `Mp3PropertyGetter.cs`.
🎯 Why: `_supportedExtensions` is initialized with `StringComparer.OrdinalIgnoreCase`. Calling `.ToUpperInvariant()` on every file extension in `IsSupportedFile` causes an unnecessary memory allocation and string conversion in a hot loop (directory enumeration).
📊 Impact: Reduces memory allocations and CPU cycles when scanning directories containing files, avoiding one string allocation per file.
🔬 Measurement: Can be verified using .NET memory profilers or benchmark runs; code compilation (`dotnet build -p:EnableWindowsTargeting=true`) succeeds.

---
*PR created automatically by Jules for task [4719660018147202543](https://jules.google.com/task/4719660018147202543) started by @bestter*