### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability in file parsers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,3 +8,8 @@
 **Vulnerability:** Found an issue where unexpected exceptions during image parsing (`Image.Identify`) were re-thrown (`throw;`) instead of being safely caught and logged.
 **Learning:** Re-throwing generic exceptions in background tasks without proper isolation can crash the main application, leading to Denial of Service (DoS) when a user scans a directory containing a maliciously crafted image file that triggers an unexpected exception in `ImageSharp`.
 **Prevention:** Always catch and log generic exceptions when parsing files from untrusted sources, ensuring that a single corrupted or malicious file does not crash the entire application.
+
+## 2024-05-23 - [DoS via Unhandled Parser Exceptions]
+**Vulnerability:** Discovered that background parsing of Mp3, Word, and Excel files did not catch generic exceptions from their respective third-party libraries (TagLib, DocumentFormat.OpenXml).
+**Learning:** In a bulk processing application, unhandled exceptions from third-party parsing libraries when encountering malformed or maliciously crafted files can bubble up and cause the entire background scan to crash, leading to a Denial of Service (DoS) vulnerability.
+**Prevention:** Always use a generic exception catch block (with `#pragma warning disable CA1031`) when passing untrusted file data to third-party parsers, logging the error and failing gracefully.

--- a/HDLG file property/ExcelPropertyGetter.cs
+++ b/HDLG file property/ExcelPropertyGetter.cs
@@ -51,6 +51,12 @@ namespace HdlgFileProperty
             {
                 Logger?.Warning(ex, "Could not open Excel file or extract properties for {Path}", path);
             }
+#pragma warning disable CA1031 // Ne pas intercepter les types d'exception générale
+            catch (Exception ex)
+            {
+                Logger?.Warning(ex, "Cannot read properties from file {Path}", path);
+            }
+#pragma warning restore CA1031 // Ne pas intercepter les types d'exception générale
 
             return properties;
         }

--- a/HDLG file property/Mp3PropertyGetter.cs
+++ b/HDLG file property/Mp3PropertyGetter.cs
@@ -77,6 +77,12 @@ namespace HdlgFileProperty
             {
                 Logger?.Warning(cfe, $"File {path} is corrupted");
             }
+#pragma warning disable CA1031 // Ne pas intercepter les types d'exception générale
+            catch (Exception e)
+            {
+                Logger?.Warning(e, "Cannot read properties from file {Path}", path);
+            }
+#pragma warning restore CA1031 // Ne pas intercepter les types d'exception générale
             return properties;
         }
 

--- a/HDLG file property/WordPropertyGetter.cs
+++ b/HDLG file property/WordPropertyGetter.cs
@@ -50,6 +50,12 @@ namespace HdlgFileProperty
             {
                 Logger?.Warning(ex, "Could not open Word file or extract properties for {Path}", path);
             }
+#pragma warning disable CA1031 // Ne pas intercepter les types d'exception générale
+            catch (Exception ex)
+            {
+                Logger?.Warning(ex, "Cannot read properties from file {Path}", path);
+            }
+#pragma warning restore CA1031 // Ne pas intercepter les types d'exception générale
 
             return properties;
         }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was susceptible to Denial of Service (DoS) during directory scans because third-party file parsing libraries (TagLib, DocumentFormat.OpenXml) could throw unexpected generic exceptions when encountering malformed or maliciously crafted files. This would bubble up, crashing the entire background processing task.
🎯 Impact: An attacker could place a single corrupted file in a directory to prevent users from successfully generating directory lists for that tree, effectively causing a DoS.
🔧 Fix: Added generic catch blocks (using `#pragma warning disable CA1031` per existing patterns) to `Mp3PropertyGetter`, `ExcelPropertyGetter`, and `WordPropertyGetter` to log the errors and fail gracefully, allowing the scan to continue.
✅ Verification: Tested compilation locally via `dotnet build -p:EnableWindowsTargeting=true`. Tests verified to pass syntax structure. Added Sentinel journal learning.

---
*PR created automatically by Jules for task [10287489539433058238](https://jules.google.com/task/10287489539433058238) started by @bestter*