### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process Injection via Extension Check Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,3 +13,8 @@
 **Vulnerability:** Discovered that background parsing of Mp3, Word, and Excel files did not catch generic exceptions from their respective third-party libraries (TagLib, DocumentFormat.OpenXml).
 **Learning:** In a bulk processing application, unhandled exceptions from third-party parsing libraries when encountering malformed or maliciously crafted files can bubble up and cause the entire background scan to crash, leading to a Denial of Service (DoS) vulnerability.
 **Prevention:** Always use a generic exception catch block (with `#pragma warning disable CA1031`) when passing untrusted file data to third-party parsers, logging the error and failing gracefully.
+
+## 2024-05-23 - [Process Injection/Security Check Bypass via File Extension]
+**Vulnerability:** The application was vulnerable to Process Injection because the blocklist for dangerous file extensions (like .exe, .bat) in `OpenWithDefaultProgram` could be bypassed by appending trailing spaces or dots to the file name.
+**Learning:** Windows Shell `Process.Start` ignores trailing spaces and dots when executing a file, but `System.IO.Path.GetExtension()` retains them. Therefore, an attacker could create a file named `malicious.bat. ` and the blocklist logic checking `Path.GetExtension` would test `.bat. ` against the list of dangerous extensions, resulting in a false negative and execution of the malicious file.
+**Prevention:** Always sanitize input paths by removing trailing spaces and dots (`TrimEnd(' ', '.')`) before extracting the file extension for security validation.

--- a/HDLG winforms/MainWindow.cs
+++ b/HDLG winforms/MainWindow.cs
@@ -221,7 +221,7 @@ toolStripStatusLabelTotalTime.Visible = false;
 				throw new FileNotFoundException( "The specified file was not found.", path );
 			}
 
-			string extension = System.IO.Path.GetExtension( path );
+			string extension = System.IO.Path.GetExtension( path.TrimEnd(' ', '.') );
 			if (DangerousExtensions.Contains( extension ))
 			{
 				throw new InvalidOperationException( $"Opening files with extension '{extension}' is not allowed for security reasons." );

--- a/HDLG.Tests/OpenWithDefaultProgramTests.cs
+++ b/HDLG.Tests/OpenWithDefaultProgramTests.cs
@@ -67,6 +67,9 @@ namespace HDLG.Tests
 		[InlineData(".cpl")]
 		[InlineData(".EXE")]
 		[InlineData(".Bat")]
+		[InlineData(".bat ")]
+		[InlineData(".exe.")]
+		[InlineData(".cmd.  ")]
 		public void OpenWithDefaultProgram_DangerousExtension_ThrowsInvalidOperationException(string extension)
 		{
 			var dangerousFile = System.IO.Path.Combine(tempDir, $"malicious{extension}");


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Process Injection via File Extension Check Bypass. The blocklist checking for dangerous file extensions (like `.bat`, `.exe`) in `OpenWithDefaultProgram` could be bypassed by adding trailing spaces or dots to the file name (e.g., `malicious.bat. `). `System.IO.Path.GetExtension` retains these characters, resulting in a false negative against the blocklist, while the Windows Shell natively ignores them during execution.
🎯 Impact: An attacker could execute arbitrary code on the system if they manage to get the application to open a specially crafted malicious file using `Process.Start`.
🔧 Fix: Sanitized the input path by removing trailing spaces and dots (`TrimEnd(' ', '.')`) before extracting and validating the file extension. Added inline tests in `HDLG.Tests/OpenWithDefaultProgramTests.cs` to explicitly check this bypass. Logged the learning in `.jules/sentinel.md`.
✅ Verification: Successfully compiled the application and tests (`dotnet build -p:EnableWindowsTargeting=true`) to verify changes. Tests specifically check the added trailing dot/space test cases.

---
*PR created automatically by Jules for task [15808362012328518796](https://jules.google.com/task/15808362012328518796) started by @bestter*