### PR TITLE
⚡ Bolt: Replace .Any() with .Count > 0 for better performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -15,3 +15,6 @@
 ## 2026-05-24 - Redundant string allocation with case-insensitive collections
 **Learning:** When using case-insensitive collections like `HashSet<string>(StringComparer.OrdinalIgnoreCase)`, calling `.ToUpperInvariant()` or similar methods on the checked string is redundant and causes unnecessary memory allocations.
 **Action:** Always check the comparer used by a collection before transforming strings for lookup. Avoid string transformations in hot loops like file enumeration.
+## 2024-05-19 - Avoid LINQ `.Any()` in Hot Loops
+**Learning:** Using `.Any()` on Collections/Lists (like `IReadOnlyList`) inside recursive or hot loops (such as XML/HTML directory serialization) causes a LINQ enumerator allocation, which creates unnecessary garbage collection overhead and reduces performance.
+**Action:** Always prefer `.Count > 0` over `.Any()` when checking if a `List` or `IReadOnlyList` has elements in performance-critical code paths.

--- a/HDLG winforms/DirectoryBrowser.cs
+++ b/HDLG winforms/DirectoryBrowser.cs
@@ -130,7 +130,7 @@ namespace HDLG_winforms
 			await writer.WriteElementStringAsync( null, "Name", null, directory.Name ).ConfigureAwait( false );
 			await writer.WriteElementStringAsync( null, "Path", null, directory.Path ).ConfigureAwait( false );
 			await writer.WriteElementStringAsync( null, "CreationTime", null, directory.CreationTime.ToString( "O", CultureInfo.InvariantCulture ) ).ConfigureAwait( false );
-			if (directory.Directories.Any( ))
+			if (directory.Directories.Count > 0)
 			{
 				await writer.WriteStartElementAsync( null, "Directories", null ).ConfigureAwait( false );
 				foreach (HdlgDirectory d in directory.Directories)
@@ -140,7 +140,7 @@ namespace HDLG_winforms
 				await writer.WriteEndElementAsync( ).ConfigureAwait( false );
 			}
 
-			if (directory.Files.Any( ))
+			if (directory.Files.Count > 0)
 			{
 				await writer.WriteStartElementAsync( null, "Files", null ).ConfigureAwait( false );
 				foreach (HdlgFile file in directory.Files)
@@ -373,7 +373,7 @@ namespace HDLG_winforms
 
 			await writer.WriteLineAsync( $"{spacer}<a href=\"#directoryList\">⬆️</a>" ).ConfigureAwait( false );
 
-			if (directory.Directories.Any( ))
+			if (directory.Directories.Count > 0)
 			{
 				await writer.WriteLineAsync( spacer + "<div class=\"directories\">" ).ConfigureAwait( false );
 				var inDepth = depth + 1;
@@ -384,7 +384,7 @@ namespace HDLG_winforms
 				await writer.WriteLineAsync( spacer + "</div>" ).ConfigureAwait( false );
 			}
 
-			if (directory.Files.Any( ))
+			if (directory.Files.Count > 0)
 			{
 				await writer.WriteLineAsync( spacer + "<div class=\"files\">" ).ConfigureAwait( false );
 				foreach (HdlgFile file in directory.Files)


### PR DESCRIPTION
💡 What: Replaced LINQ `.Any()` calls with `.Count > 0` checks for `directory.Directories` and `directory.Files` inside `HDLG winforms/DirectoryBrowser.cs`.
🎯 Why: `.Any()` on an `IReadOnlyList` or `List` allocates a new enumerator instance under the hood. In the hot path of directory serialization (which recursively calls these lines for potentially thousands of directories and files), this creates significant unnecessary garbage collection pressure and reduces iteration performance.
📊 Impact: Expected to reduce memory allocations and slightly speed up the XML and HTML generation process for large directory structures.
🔬 Measurement: Run a profiler on `DirectoryBrowser` when serializing a large directory; fewer garbage collection cycles and enumerator allocations should be observed.

---
*PR created automatically by Jules for task [8835013657776719762](https://jules.google.com/task/8835013657776719762) started by @bestter*