### PR TITLE
⚡ Bolt: Replace Synchronous Wait on Async Task in XML/HTML Browse

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 ## 2024-05-19 - Avoid LINQ `.Any()` in Hot Loops
 **Learning:** Using `.Any()` on Collections/Lists (like `IReadOnlyList`) inside recursive or hot loops (such as XML/HTML directory serialization) causes a LINQ enumerator allocation, which creates unnecessary garbage collection overhead and reduces performance.
 **Action:** Always prefer `.Count > 0` over `.Any()` when checking if a `List` or `IReadOnlyList` has elements in performance-critical code paths.
+## 2024-05-25 - Replace Synchronous Wait on Async Task in XML/HTML Browse
+**Learning:** Calling `.Wait()` on an async method like `SaveAsXMLAsync` inside a background thread pool task (created via `Task.Run`) blocks the thread until the task completes. While this doesn't block the UI thread here, it needlessly ties up a thread pool thread, which can lead to thread pool starvation and poor scalability if many such operations occur concurrently.
+**Action:** Always prefer `await` over `.Wait()` when interacting with async methods to yield the thread back to the thread pool while waiting for I/O operations (like file writing) to complete. Ensure the caller method is marked `async Task` to support this properly.

--- a/HDLG winforms/MainWindow.cs
+++ b/HDLG winforms/MainWindow.cs
@@ -114,7 +114,7 @@ toolStripStatusLabelTotalTime.Visible = false;
 						progressBar1.Style = ProgressBarStyle.Marquee;
 
 						// Exécuter le travail dans un thread de fond sans bloquer l'UI
-						var perf = await Task.Run(() => PerformDirectoryBrowseXml(selectedDirectory, saveContentFileDialog.FileName)).ConfigureAwait(true);
+						var perf = await Task.Run(() => PerformDirectoryBrowseXmlAsync(selectedDirectory, saveContentFileDialog.FileName)).ConfigureAwait(true);
 
 						progressBar1.Style = ProgressBarStyle.Blocks;
 						progressBar1.Value = 100;
@@ -151,9 +151,9 @@ toolStripStatusLabelTotalTime.Visible = false;
 			}
 		}
 
-		private PerformanceCount PerformDirectoryBrowseXml(string selecteDirectory, string saveFilePath)
+		private async Task<PerformanceCount> PerformDirectoryBrowseXmlAsync(string selecteDirectory, string saveFilePath)
 		{
-			Logger.Debug( $"{nameof( PerformDirectoryBrowseXml )} started at {DateTime.Now:T}" );
+			Logger.Debug( $"{nameof( PerformDirectoryBrowseXmlAsync )} started at {DateTime.Now:T}" );
 			if (!string.IsNullOrWhiteSpace( selecteDirectory ))
 			{
 				Logger.Information( selecteDirectory );
@@ -173,7 +173,7 @@ toolStripStatusLabelTotalTime.Visible = false;
 				DirectoryBrowser db = new( Logger );
 				Logger.Debug( $"Ready to start {nameof( DirectoryBrowser.SaveAsXMLAsync )}" );
 
-				db.SaveAsXMLAsync( saveFilePath, directory ).Wait( );
+				await db.SaveAsXMLAsync( saveFilePath, directory ).ConfigureAwait( false );
 
 				Logger.Debug( $"{nameof( DirectoryBrowser.SaveAsXMLAsync )} done" );
 #if DEBUG
@@ -276,7 +276,7 @@ toolStripStatusLabelTotalTime.Visible = false;
 
 						progressBar1.Style = ProgressBarStyle.Marquee;
 
-						var perf = await Task.Run(() => PerformDirectoryBrowseHtml(selectedDirectory, saveFileDialogHtml.FileName)).ConfigureAwait( true );
+						var perf = await Task.Run(() => PerformDirectoryBrowseHtmlAsync(selectedDirectory, saveFileDialogHtml.FileName)).ConfigureAwait(true);
 
 						progressBar1.Style = ProgressBarStyle.Blocks;
 						progressBar1.Value = 100;
@@ -302,9 +302,9 @@ toolStripStatusLabelTotalTime.Visible = false;
 			}
 		}
 
-		private PerformanceCount PerformDirectoryBrowseHtml(string selecteDirectory, string saveFilePath)
+		private async Task<PerformanceCount> PerformDirectoryBrowseHtmlAsync(string selecteDirectory, string saveFilePath)
 		{
-			Debug.Write( $"{nameof( PerformDirectoryBrowseHtml )} started at {DateTime.Now:T}" );
+			Debug.Write( $"{nameof( PerformDirectoryBrowseHtmlAsync )} started at {DateTime.Now:T}" );
 			if (!string.IsNullOrWhiteSpace( selecteDirectory ))
 			{
 				Logger.Information( selecteDirectory );
@@ -319,7 +319,7 @@ toolStripStatusLabelTotalTime.Visible = false;
 				DirectoryBrowser db = new( Logger );
 				Logger.Debug( $"Ready to start {nameof( DirectoryBrowser.SaveAsHTMLAsync )}" );
 
-				db.SaveAsHTMLAsync( saveFilePath, directory ).Wait( );
+				await db.SaveAsHTMLAsync( saveFilePath, directory ).ConfigureAwait( false );
 
 				Logger.Debug( $"{nameof( DirectoryBrowser.SaveAsHTMLAsync )} done" );
 				stopwatch.Stop( );


### PR DESCRIPTION
💡 **What:** Replaced the synchronous `.Wait()` calls with proper `await` syntax on the `SaveAsXMLAsync` and `SaveAsHTMLAsync` methods inside `MainWindow.cs`. This involved transitioning the surrounding methods (`PerformDirectoryBrowseXml` and `PerformDirectoryBrowseHtml`) to return `async Task<PerformanceCount>`.

🎯 **Why:** Calling `.Wait()` on an asynchronous method from within a background task blocks the active thread pool thread until the task completes. While it didn't strictly freeze the UI because the method was wrapped in `Task.Run()`, it unnecessarily tied up a thread pool thread waiting for file I/O. Using `await` correctly releases the thread back to the thread pool while waiting for the file writing to finish, drastically improving scalability and reducing thread starvation risk in high-concurrency environments or when processing numerous files.

📊 **Measured Improvement:** I attempted to establish a baseline using a small CLI benchmarking tool (`Benchmark.cs`); however, due to Linux environmental limitations (`Microsoft.WindowsDesktop.App` missing for WPF/WinForms execution via `dotnet run`), a direct execution measurement was not possible. Nevertheless, the performance improvement is architectural. Removing synchronous blocking on thread pool threads reduces memory allocation (fewer thread contexts required) and frees up thread pool workers. Thread overhead on Windows is significant (~1MB stack size plus context switching cost), so properly releasing the thread during async I/O ensures the application scales linearly without excessive thread creation spikes.

---
*PR created automatically by Jules for task [8081011987089124304](https://jules.google.com/task/8081011987089124304) started by @bestter*