### PR TITLE
🧪 Add tests for PdfPropertyGetter.GetFileProperties

### DIFF
--- a/HDLG.Tests/HDLG.Tests.csproj
+++ b/HDLG.Tests/HDLG.Tests.csproj
@@ -36,4 +36,10 @@
     <ProjectReference Include="..\HDLG file property\HdlgFileProperty.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="*.pdf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/HDLG.Tests/PropertyGetterTests.cs
+++ b/HDLG.Tests/PropertyGetterTests.cs
@@ -75,6 +75,66 @@ namespace HDLG.Tests
             result.Should().Be(expected);
         }
 
+
+        [Fact]
+        public void PdfPropertyGetter_GetFileProperties_ValidFileWithTitle_ReturnsTitle()
+        {
+            // Arrange
+            var getter = new PdfPropertyGetter();
+
+            // Act
+            var properties = getter.GetFileProperties("test.pdf");
+
+            // Assert
+            properties.Should().ContainKey("Title");
+            properties["Title"].Should().Be("Test PDF Title");
+        }
+
+        [Fact]
+        public void PdfPropertyGetter_GetFileProperties_ValidFileWithoutTitle_ReturnsEmptyDictionary()
+        {
+            // Arrange
+            var getter = new PdfPropertyGetter();
+
+            // Act
+            var properties = getter.GetFileProperties("test_empty_title.pdf");
+
+            // Assert
+            properties.Should().NotContainKey("Title");
+            properties.Should().BeEmpty();
+
+        }
+
+        [Fact]
+        public void PdfPropertyGetter_GetFileProperties_FileNotFound_LogsErrorAndReturnsEmpty()
+        {
+            // Arrange
+            var getter = new PdfPropertyGetter();
+            getter.AddLogger(loggerMock.Object);
+
+            // Act
+            var properties = getter.GetFileProperties("nonexistent.pdf");
+
+            // Assert
+
+            loggerMock.Verify(l => l.Error(It.IsAny<Exception>(), It.Is<string>(s => s.Contains("Cannot read file"))), Times.Once);
+        }
+
+        [Fact]
+        public void PdfPropertyGetter_GetFileProperties_InvalidFileFormat_LogsWarningAndReturnsEmpty()
+        {
+            // Arrange
+            var getter = new PdfPropertyGetter();
+            getter.AddLogger(loggerMock.Object);
+
+            // Act
+            var properties = getter.GetFileProperties("test_invalid.pdf");
+
+            // Assert
+
+            loggerMock.Verify(l => l.Warning(It.IsAny<Exception>(), It.Is<string>(s => s.Contains("Cannot read properties from file"))), Times.Once);
+        }
+
         [Theory]
         [InlineData("test.pdf", true)]
         [InlineData("test.txt", false)]

--- a/HDLG.Tests/test.pdf
+++ b/HDLG.Tests/test.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260525184448+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260525184448+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title (Test PDF Title) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 100
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90EC-p>QkRte=<%VL%,#7S.n\OO=Z(s/WaEF/cZcD'.3~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f
+0000000061 00000 n
+0000000092 00000 n
+0000000199 00000 n
+0000000402 00000 n
+0000000470 00000 n
+0000000737 00000 n
+0000000796 00000 n
+trailer
+<<
+/ID
+[<d33e1e7935c55b29302a5063aeacdf38><d33e1e7935c55b29302a5063aeacdf38>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+986
+%%EOF

--- a/HDLG.Tests/test_empty_title.pdf
+++ b/HDLG.Tests/test_empty_title.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260525191829+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260525191829+00'00') /Producer (ReportLab PDF Library - \(opensource\))
+  /Subject (unspecified) /Title () /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 100
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90EC-p>QkRte=<%VL%,#7S.n\OO=Z(s/WaEF/cZcD'.3~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f
+0000000061 00000 n
+0000000092 00000 n
+0000000199 00000 n
+0000000402 00000 n
+0000000470 00000 n
+0000000723 00000 n
+0000000782 00000 n
+trailer
+<<
+/ID
+[<c47ae09348963dccad3e44adcd830528><c47ae09348963dccad3e44adcd830528>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+972
+%%EOF

--- a/HDLG.Tests/test_invalid.pdf
+++ b/HDLG.Tests/test_invalid.pdf
@@ -1,0 +1,1 @@
+This is a fake pdf file.

--- a/pr.txt
+++ b/pr.txt
@@ -1,0 +1,9 @@
+🧪 Add tests for PdfPropertyGetter.GetFileProperties
+
+🎯 **What:** Added tests for the untesteted `GetFileProperties` method in `PdfPropertyGetter.cs`
+📊 **Coverage:** Covered multiple scenarios:
+    - Reading a valid PDF with a title.
+    - Reading a valid PDF without a title.
+    - Trying to read a nonexistent file (logs Error).
+    - Trying to read an invalid PDF format (logs Warning).
+✨ **Result:** Test coverage improved with the required happy path, missing properties handling, and exception handling paths.


### PR DESCRIPTION
🎯 **What:** Added unit tests for the untested `GetFileProperties` method in `PdfPropertyGetter`.
📊 **Coverage:** Covered multiple scenarios: 
    - Reading a valid PDF with a title (happy path).
    - Reading a valid PDF without a title.
    - Trying to read a nonexistent file (triggers `IOException`, logs `Error`).
    - Trying to read an invalid PDF format (triggers `Exception`, logs `Warning`).
✨ **Result:** Test coverage improved for the PDF property extractor, ensuring robust handling of valid, invalid, and missing files without crashing.

---
*PR created automatically by Jules for task [10983180602441146464](https://jules.google.com/task/10983180602441146464) started by @bestter*