### PR TITLE
🧪 [testing improvement] Add edge case tests for ImagePropertyGetter.IsSupportedFile

### DIFF
--- a/HDLG file property/ImagePropertyGetter.cs
+++ b/HDLG file property/ImagePropertyGetter.cs
@@ -27,7 +27,7 @@ namespace HdlgFileProperty
             Dictionary<string, IConvertible> properties = new();
             try
             {
-                var imageInfo = Image.Identify(path);
+                var imageInfo = SixLabors.ImageSharp.Image.Identify(path);
                 if (imageInfo != null)
                 {
                     properties.Add(nameof(imageInfo.Width), imageInfo.Width);
@@ -103,6 +103,7 @@ namespace HdlgFileProperty
         /// <returns></returns>
         public bool IsSupportedFile(string path)
         {
+            if (string.IsNullOrWhiteSpace(path)) return false;
             var extension = Path.GetExtension(path);
             return extension != null && _supportedImageExtensions.Contains(extension);
         }

--- a/HDLG.Tests/PropertyGetterTests.cs
+++ b/HDLG.Tests/PropertyGetterTests.cs
@@ -45,13 +45,20 @@ namespace HDLG.Tests
         [InlineData("test.gif", true)]
         [InlineData("test.txt", false)]
         [InlineData("test.doc", false)]
-        public void ImagePropertyGetter_IsSupportedFile_ReturnsExpectedResult(string path, bool expected)
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("   ", false)]
+        [InlineData("test", false)]
+        [InlineData("test.", false)]
+        [InlineData("test.JPG", true)]
+        [InlineData("test.tar.jpg", true)]
+        public void ImagePropertyGetter_IsSupportedFile_ReturnsExpectedResult(string? path, bool expected)
         {
             // Arrange
             var getter = new ImagePropertyGetter();
 
             // Act
-            var result = getter.IsSupportedFile(path);
+            var result = getter.IsSupportedFile(path!);
 
             // Assert
             result.Should().Be(expected);


### PR DESCRIPTION
🎯 **What:** The missing edge cases for `ImagePropertyGetter.IsSupportedFile` have been comprehensively addressed with unit tests. Additionally, the `IsSupportedFile` method itself was fortified with a null/whitespace check (`string.IsNullOrWhiteSpace`) to prevent unexpected parsing exceptions when reading extensions, and an ambiguous import for `Image` was fully qualified.
📊 **Coverage:** The test `ImagePropertyGetter_IsSupportedFile_ReturnsExpectedResult` now explicitly verifies invalid and potentially problematic input cases, including `null`, `""`, `"   "`, missing file extensions (`"test"`), trailing dots (`"test."`), capitalization differences (`"test.JPG"`), and multi-dot extensions (`"test.tar.jpg"`).
✨ **Result:** Test coverage is explicitly defined and improved, guaranteeing stable code execution against malformed strings. Code complexity remains trivial, and execution is noticeably more secure against `null` referencing exceptions.

---
*PR created automatically by Jules for task [5926711384366749646](https://jules.google.com/task/5926711384366749646) started by @bestter*