### PR TITLE
⚡ Bolt: Avoid eager dictionary allocation in property getters

### DIFF
--- a/HDLG file property/ExcelPropertyGetter.cs
+++ b/HDLG file property/ExcelPropertyGetter.cs
@@ -35,7 +35,7 @@ namespace HdlgFileProperty
 
                 if (!string.IsNullOrWhiteSpace(packageProperties.Title))
                 {
-                    properties ??= new Dictionary<string, IConvertible>(3);
+                    properties = new Dictionary<string, IConvertible>(3);
                     properties.Add("Title", packageProperties.Title);
                 }
 

--- a/HDLG file property/ExcelPropertyGetter.cs
+++ b/HDLG file property/ExcelPropertyGetter.cs
@@ -15,6 +15,8 @@ namespace HdlgFileProperty
 {
     public class ExcelPropertyGetter : IFilePropertyGetter
     {
+        private static readonly IReadOnlyDictionary<string, IConvertible> EmptyProperties = new System.Collections.ObjectModel.ReadOnlyDictionary<string, IConvertible>(new Dictionary<string, IConvertible>());
+
         public ILogger? Logger { get; private set; }
 
         public void AddLogger(ILogger logger)
@@ -22,9 +24,9 @@ namespace HdlgFileProperty
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public Dictionary<string, IConvertible> GetFileProperties(string path)
+        public IReadOnlyDictionary<string, IConvertible> GetFileProperties(string path)
         {
-            Dictionary<string, IConvertible> properties = new(3);
+            Dictionary<string, IConvertible>? properties = null;
             try
             {
                 using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -33,17 +35,20 @@ namespace HdlgFileProperty
 
                 if (!string.IsNullOrWhiteSpace(packageProperties.Title))
                 {
+                    properties ??= new Dictionary<string, IConvertible>(3);
                     properties.Add("Title", packageProperties.Title);
                 }
 
                 DateTime? created = packageProperties.Created;
                 if (created != null)
                 {
+                    properties ??= new Dictionary<string, IConvertible>(3);
                     properties.Add("Created", created.Value);
                 }
 
                 if (!string.IsNullOrWhiteSpace(packageProperties.Creator))
                 {
+                    properties ??= new Dictionary<string, IConvertible>(3);
                     properties.Add("Creator", packageProperties.Creator);
                 }
             }
@@ -58,7 +63,7 @@ namespace HdlgFileProperty
             }
 #pragma warning restore CA1031 // Ne pas intercepter les types d'exception générale
 
-            return properties;
+            return properties ?? EmptyProperties;
         }
 
         public bool IsSupportedFile(string path)

--- a/HDLG file property/IFilePropertyGetter.cs
+++ b/HDLG file property/IFilePropertyGetter.cs
@@ -31,6 +31,6 @@ namespace HdlgFileProperty
         /// </summary>
         /// <param name="path">The full file path</param>
         /// <returns></returns>
-        Dictionary<string, IConvertible> GetFileProperties(string path);
+        IReadOnlyDictionary<string, IConvertible> GetFileProperties(string path);
     }
 }

--- a/HDLG file property/ImagePropertyGetter.cs
+++ b/HDLG file property/ImagePropertyGetter.cs
@@ -15,6 +15,7 @@ namespace HdlgFileProperty
 {
     public class ImagePropertyGetter : IFilePropertyGetter
     {
+        private static readonly IReadOnlyDictionary<string, IConvertible> EmptyProperties = new System.Collections.ObjectModel.ReadOnlyDictionary<string, IConvertible>(new Dictionary<string, IConvertible>());
 
         public ILogger? Logger { get; private set; }
 
@@ -22,14 +23,15 @@ namespace HdlgFileProperty
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
-        public Dictionary<string, IConvertible> GetFileProperties(string path)
+        public IReadOnlyDictionary<string, IConvertible> GetFileProperties(string path)
         {
-            Dictionary<string, IConvertible> properties = new();
+            Dictionary<string, IConvertible>? properties = null;
             try
             {
                 var imageInfo = SixLabors.ImageSharp.Image.Identify(path);
                 if (imageInfo != null)
                 {
+                    properties = new Dictionary<string, IConvertible>();
                     properties.Add(nameof(imageInfo.Width), imageInfo.Width);
                     properties.Add(nameof(imageInfo.Height), imageInfo.Height);
 
@@ -63,7 +65,7 @@ namespace HdlgFileProperty
                 Logger?.Warning(e, "Cannot read properties from file: {FilePath}", path);
             }
 #pragma warning restore CA1031 // Ne pas intercepter les types d'exception générale
-            return properties;
+            return properties ?? EmptyProperties;
         }
 
         private static readonly HashSet<string> _supportedImageExtensions = new(StringComparer.OrdinalIgnoreCase)

--- a/HDLG file property/Mp3PropertyGetter.cs
+++ b/HDLG file property/Mp3PropertyGetter.cs
@@ -14,6 +14,8 @@ namespace HdlgFileProperty
 {
     public class Mp3PropertyGetter : IFilePropertyGetter
     {
+        private static readonly IReadOnlyDictionary<string, IConvertible> EmptyProperties = new System.Collections.ObjectModel.ReadOnlyDictionary<string, IConvertible>(new Dictionary<string, IConvertible>());
+
         public ILogger? Logger { get; private set; }
 
         public void AddLogger(ILogger logger)
@@ -21,10 +23,10 @@ namespace HdlgFileProperty
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public Dictionary<string, IConvertible> GetFileProperties(string path)
+        public IReadOnlyDictionary<string, IConvertible> GetFileProperties(string path)
         {
             Logger?.Verbose($"In {nameof(Mp3PropertyGetter)}.{nameof(GetFileProperties)}: {path}");
-            Dictionary<string, IConvertible> properties = new();
+            Dictionary<string, IConvertible>? properties = null;
             try
             {
                 using TagLib.File f = TagLib.File.Create(path);
@@ -32,6 +34,7 @@ namespace HdlgFileProperty
                 {
                     if (!f.Tag.IsEmpty)
                     {
+                        properties = new Dictionary<string, IConvertible>();
                         properties.Add(nameof(f.Tag.Title), f.Tag.Title);
 
                         properties.Add(nameof(f.Properties.Duration), f.Properties.Duration.ToString("G", CultureInfo.CurrentCulture));
@@ -83,7 +86,7 @@ namespace HdlgFileProperty
                 Logger?.Warning(e, "Cannot read properties from file {Path}", path);
             }
 #pragma warning restore CA1031 // Ne pas intercepter les types d'exception générale
-            return properties;
+            return properties ?? EmptyProperties;
         }
 
         private static readonly HashSet<string> _supportedExtensions = new(StringComparer.OrdinalIgnoreCase)

--- a/HDLG file property/PdfPropertyGetter.cs
+++ b/HDLG file property/PdfPropertyGetter.cs
@@ -14,6 +14,8 @@ namespace HdlgFileProperty
 {
     public class PdfPropertyGetter : IFilePropertyGetter
     {
+        private static readonly IReadOnlyDictionary<string, IConvertible> EmptyProperties = new System.Collections.ObjectModel.ReadOnlyDictionary<string, IConvertible>(new Dictionary<string, IConvertible>());
+
         public ILogger? Logger { get; private set; }
 
         public void AddLogger(ILogger logger)
@@ -21,9 +23,9 @@ namespace HdlgFileProperty
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public Dictionary<string, IConvertible> GetFileProperties(string path)
+        public IReadOnlyDictionary<string, IConvertible> GetFileProperties(string path)
         {
-            Dictionary<string, IConvertible> properties = new();
+            Dictionary<string, IConvertible>? properties = null;
 #pragma warning disable CA1031 // Ne pas intercepter les types d'exception générale
             try
             {
@@ -32,6 +34,7 @@ namespace HdlgFileProperty
 
                 if (!string.IsNullOrWhiteSpace(title))
                 {
+                    properties = new Dictionary<string, IConvertible>();
                     properties.Add("Title", title);
                 }
             }
@@ -49,7 +52,7 @@ namespace HdlgFileProperty
             }
 #pragma warning restore CA1031 // Ne pas intercepter les types d'exception générale
 
-            return properties;
+            return properties ?? EmptyProperties;
         }
 
         public bool IsSupportedFile(string path)

--- a/HDLG file property/WordPropertyGetter.cs
+++ b/HDLG file property/WordPropertyGetter.cs
@@ -34,7 +34,7 @@ namespace HdlgFileProperty
 
                 if (!string.IsNullOrWhiteSpace(packageProperties.Title))
                 {
-                    properties ??= new Dictionary<string, IConvertible>(3);
+                    properties = new Dictionary<string, IConvertible>(3);
                     properties.Add("Title", packageProperties.Title);
                 }
 

--- a/HDLG file property/WordPropertyGetter.cs
+++ b/HDLG file property/WordPropertyGetter.cs
@@ -14,6 +14,8 @@ namespace HdlgFileProperty
 {
     public class WordPropertyGetter : IFilePropertyGetter
     {
+        private static readonly IReadOnlyDictionary<string, IConvertible> EmptyProperties = new System.Collections.ObjectModel.ReadOnlyDictionary<string, IConvertible>(new Dictionary<string, IConvertible>());
+
         public ILogger? Logger { get; private set; }
 
         public void AddLogger(ILogger logger)
@@ -21,9 +23,9 @@ namespace HdlgFileProperty
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public Dictionary<string, IConvertible> GetFileProperties(string path)
+        public IReadOnlyDictionary<string, IConvertible> GetFileProperties(string path)
         {
-            Dictionary<string, IConvertible> properties = new(3);
+            Dictionary<string, IConvertible>? properties = null;
             try
             {
                 using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -32,17 +34,20 @@ namespace HdlgFileProperty
 
                 if (!string.IsNullOrWhiteSpace(packageProperties.Title))
                 {
+                    properties ??= new Dictionary<string, IConvertible>(3);
                     properties.Add("Title", packageProperties.Title);
                 }
 
                 DateTime? created = packageProperties.Created;
                 if (created != null)
                 {
+                    properties ??= new Dictionary<string, IConvertible>(3);
                     properties.Add("Created", created.Value);
                 }
 
                 if (!string.IsNullOrWhiteSpace(packageProperties.Creator))
                 {
+                    properties ??= new Dictionary<string, IConvertible>(3);
                     properties.Add("Creator", packageProperties.Creator);
                 }
             }
@@ -57,7 +62,7 @@ namespace HdlgFileProperty
             }
 #pragma warning restore CA1031 // Ne pas intercepter les types d'exception générale
 
-            return properties;
+            return properties ?? EmptyProperties;
         }
 
         public bool IsSupportedFile(string path)


### PR DESCRIPTION
💡 **What:** Updated all implementations of `IFilePropertyGetter` and its interface to return `IReadOnlyDictionary<string, IConvertible>`. Instantiation of the properties dictionary is delayed until the first property is successfully read. If no properties are found or an error occurs, a static, shared `EmptyProperties` dictionary is returned instead of allocating a new empty dictionary.

🎯 **Why:** To prevent eager memory allocation and garbage generation. Eagerly allocating a dictionary when properties might not be read or when a file type isn't supported unnecessarily increases GC pressure in hot paths (like parsing thousands of files).

📊 **Impact:** Reduces dictionary allocations to zero for unsupported or empty files during directory traversal, saving substantial GC overhead in directory processing loops.

🔬 **Measurement:** Running the directory traversal should show lower memory consumption and fewer Gen 0 garbage collections on large folders with numerous mixed files. Use `dotnet test` to confirm unit tests handle the new return type correctly.

---
*PR created automatically by Jules for task [6870247899564582910](https://jules.google.com/task/6870247899564582910) started by @bestter*