### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS risk in directory traversal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -28,3 +28,8 @@
 **Vulnerability:** A "fail-open" pattern existed where an actionable UI button (`btnOpenFile`) was aggressively enabled *before* executing security validations (like `IsPathWithinRoot`), meaning an unexpected exception during validation would leave the dangerous action available.
 **Learning:** Security validations should gate state changes. Enabling UI elements that trigger privileged or dangerous actions prior to confirming the safety of those actions can result in an authorization bypass if error-handling logic returns early.
 **Prevention:** To prevent 'fail-open' authorization bypasses in UI components, ensure all security and validation checks (such as path traversal verifications) execute and pass successfully before enabling actionable UI controls. Additionally, implement defense-in-depth by re-verifying security constraints directly inside the button click execution handler.
+
+## 2024-05-29 - [DoS/Unauthorized Access via Directory Traversal]
+**Vulnerability:** Recursive directory traversals using `EnumerateDirectories` did not check for reparse points (symbolic links or directory junctions).
+**Learning:** Failing to check for `FileAttributes.ReparsePoint` when enumerating directories can lead to infinite recursion (Denial of Service) if a cyclic symbolic link exists, or allow an attacker to traverse outside the intended directory scope by creating a symbolic link to an unauthorized location.
+**Prevention:** Always check for and skip directories with the `FileAttributes.ReparsePoint` attribute during recursive directory traversals (`if ((dir.Attributes & FileAttributes.ReparsePoint) != 0) continue;`).

--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -97,6 +97,7 @@ namespace HDLG_winforms
                     var dirNodes = new List<TreeNode>();
                     foreach (var dir in dirInfo.EnumerateDirectories())
                     {
+                        if ((dir.Attributes & FileAttributes.ReparsePoint) != 0) continue;
                         var node = new TreeNode(dir.Name);
                         node.Tag = new NodeInfo { IsDirectory = true, Path = dir.FullName };
                         node.Nodes.Add(new TreeNode("Loading..."));

--- a/HDLG winforms/HdlgDirectory.cs
+++ b/HDLG winforms/HdlgDirectory.cs
@@ -84,6 +84,7 @@ namespace HDLG_winforms
             {
                 foreach (var d in directoryInfo.EnumerateDirectories())
                 {
+                    if ((d.Attributes & FileAttributes.ReparsePoint) != 0) continue;
                     directories.Add(new HdlgDirectory(d, false, true, log));
                 }
                 directories.Sort();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Recursive directory traversals using `EnumerateDirectories` did not check for reparse points (symbolic links or directory junctions), which could lead to infinite recursion (Denial of Service) if a cyclic symbolic link exists, or allow an attacker to traverse outside the intended directory scope.
🎯 Impact: An attacker could create a symbolic link that points to an unauthorized location, or create a cyclic link that causes the application to crash due to a StackOverflowException or OutOfMemoryException, resulting in Denial of Service.
🔧 Fix: Added a check for `FileAttributes.ReparsePoint` in the directory enumeration loops in `BrowserForm.cs` and `HdlgDirectory.cs` to skip reparse points.
✅ Verification: Built the project successfully. The fix is straightforward and relies on standard .NET attributes for identifying symlinks and directory junctions.

---
*PR created automatically by Jules for task [12141981815792887678](https://jules.google.com/task/12141981815792887678) started by @bestter*