### PR TITLE
🛡️ Sentinel: [Enhancement] Add Content Security Policy to HTML exports

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -38,3 +38,8 @@
 **Vulnerability:** Recursive directory traversals using `EnumerateDirectories` did not check for reparse points (symbolic links or directory junctions).
 **Learning:** Failing to check for `FileAttributes.ReparsePoint` when enumerating directories can lead to infinite recursion (Denial of Service) if a cyclic symbolic link exists, or allow an attacker to traverse outside the intended directory scope by creating a symbolic link to an unauthorized location.
 **Prevention:** Always check for and skip directories with the `FileAttributes.ReparsePoint` attribute during recursive directory traversals (`if ((dir.Attributes & FileAttributes.ReparsePoint) != 0) continue;`).
+
+## 2026-05-30 - [XSS Defense in Depth via CSP]
+**Vulnerability:** While XSS vulnerabilities in HTML exports were previously mitigated via `WebUtility.HtmlEncode`, relying solely on encoding can be brittle if future changes introduce unencoded output paths.
+**Learning:** Static HTML exports should use a restrictive Content Security Policy (CSP) to ensure scripts cannot be executed and data cannot be exfiltrated, even if an XSS vulnerability is introduced later.
+**Prevention:** Add a strict CSP meta tag (`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none';">`) to all generated HTML exports.

--- a/HDLG winforms/DirectoryBrowser.cs
+++ b/HDLG winforms/DirectoryBrowser.cs
@@ -254,6 +254,7 @@ namespace HDLG_winforms
 			await sw.WriteLineAsync( "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "<meta name=\"robots\" content=\"noindex, nofollow\">" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "<meta name=\"rating\" content=\"general\">" ).ConfigureAwait( false );
+			await sw.WriteLineAsync( "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none';\">" ).ConfigureAwait( false );
 			await sw.WriteAsync( $"<title>{encodedTitle}</title>" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( GetGoogleFontHeader( ) ).ConfigureAwait( false );
 			await sw.WriteLineAsync( await GetCssAsync( ).ConfigureAwait( false ) ).ConfigureAwait( false );

--- a/HDLG.Tests/DirectoryBrowserTests.cs
+++ b/HDLG.Tests/DirectoryBrowserTests.cs
@@ -109,6 +109,8 @@ namespace HDLG.Tests
             htmlContent.Should().Contain($"<h2>{WebUtility.HtmlEncode(testDirectory.Path)}</h2>");
             htmlContent.Should().Contain("</html>");
 
+            htmlContent.Should().Contain("<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none';\">");
+
             // 2026 modern responsive HTML assertions (updated for prettier redesign using details/summary + clean cards)
             htmlContent.Should().Contain("<details class=\"directory\"");
             htmlContent.Should().Contain("<summary>");


### PR DESCRIPTION
🚨 **Severity:** MEDIUM (Defense-in-Depth)

💡 **Vulnerability:** Although the current codebase sanitizes HTML outputs correctly, a future regression might introduce an unescaped payload leading to Cross-Site Scripting (XSS).
🎯 **Impact:** If an XSS vulnerability occurs, it could execute arbitrary scripts in the user's browser when they open the exported HTML report.
🔧 **Fix:** Added a strict Content-Security-Policy (CSP) meta tag that disables all external resources, scripts, forms, and base URIs, allowing only inline styles (`unsafe-inline`) required by the application's self-contained CSS.
✅ **Verification:** Unit tests have been updated to confirm the CSP meta tag exists in the HTML `<head>`. 

*Note: The code review raised a concern about external Google fonts breaking with this CSP, but `GetGoogleFontHeader()` was recently updated to return an empty string and use system fonts only, so the strict CSP is completely safe and won't cause regressions.*

---
*PR created automatically by Jules for task [4220152586349318484](https://jules.google.com/task/4220152586349318484) started by @bestter*