### PR TITLE
⚡ Bolt: Combine directory and file enumeration for single-pass I/O efficiency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,6 @@
 ## 2024-06-03 - Prevent eager string allocations in logging
 **Learning:** Using interpolated strings (`$""`) inside logging calls (e.g., `Logger?.Warning($"File {path} might be corrupted...");`) forces the string to be allocated and formatted eagerly *before* the logger checks if the log level is actually enabled. This creates unnecessary garbage collection overhead, especially during repetitive operations or inside loops.
 **Action:** Always use structured logging message templates provided by Serilog (e.g., `Logger?.Warning("File {Path} might be corrupted...", path);`) instead of string interpolation to ensure strings are only allocated if the corresponding log level is enabled.
+## 2024-05-19 - Combine Directory and File Enumeration for Single-Pass I/O
+**Learning:** Making separate consecutive calls to `DirectoryInfo.EnumerateDirectories()` and `DirectoryInfo.EnumerateFiles()` on the same path forces the OS to scan the directory contents twice. In hot paths like deep recursive traversal, this severely degrades performance and wastes I/O bandwidth.
+**Action:** Always prefer a single pass using `DirectoryInfo.EnumerateFileSystemInfos()`, checking `if (info is DirectoryInfo)` and `else if (info is FileInfo)` inside the loop, halving system calls and allocation overhead for directory reads.

--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -95,23 +95,27 @@ namespace HDLG_winforms
                     var dirInfo = new DirectoryInfo(info.Path);
 
                     var dirNodes = new List<TreeNode>();
-                    foreach (var dir in dirInfo.EnumerateDirectories())
-                    {
-                        if ((dir.Attributes & FileAttributes.ReparsePoint) != 0) continue;
-                        var node = new TreeNode(dir.Name);
-                        node.Tag = new NodeInfo { IsDirectory = true, Path = dir.FullName };
-                        node.Nodes.Add(new TreeNode("Loading..."));
-                        dirNodes.Add(node);
-                    }
-                    if (dirNodes.Count > 0) e.Node.Nodes.AddRange(dirNodes.ToArray());
-
                     var fileNodes = new List<TreeNode>();
-                    foreach (var file in dirInfo.EnumerateFiles())
+
+                    foreach (var fsInfo in dirInfo.EnumerateFileSystemInfos())
                     {
-                        var node = new TreeNode(file.Name);
-                        node.Tag = new NodeInfo { IsDirectory = false, Path = file.FullName };
-                        fileNodes.Add(node);
+                        if (fsInfo is DirectoryInfo dir)
+                        {
+                            if ((dir.Attributes & FileAttributes.ReparsePoint) != 0) continue;
+                            var node = new TreeNode(dir.Name);
+                            node.Tag = new NodeInfo { IsDirectory = true, Path = dir.FullName };
+                            node.Nodes.Add(new TreeNode("Loading..."));
+                            dirNodes.Add(node);
+                        }
+                        else if (fsInfo is FileInfo file)
+                        {
+                            var node = new TreeNode(file.Name);
+                            node.Tag = new NodeInfo { IsDirectory = false, Path = file.FullName };
+                            fileNodes.Add(node);
+                        }
                     }
+
+                    if (dirNodes.Count > 0) e.Node.Nodes.AddRange(dirNodes.ToArray());
                     if (fileNodes.Count > 0) e.Node.Nodes.AddRange(fileNodes.ToArray());
                 }
                 catch (UnauthorizedAccessException ex)

--- a/HDLG winforms/HdlgDirectory.cs
+++ b/HDLG winforms/HdlgDirectory.cs
@@ -82,24 +82,35 @@ namespace HDLG_winforms
 
             if (BrowseSubdirectory)
             {
-                foreach (var d in directoryInfo.EnumerateDirectories())
+                foreach (var info in directoryInfo.EnumerateFileSystemInfos())
                 {
-                    // Prevent infinite recursion / DoS from symlinks looping back to parents
-                    if ((d.Attributes & FileAttributes.ReparsePoint) != 0)
+                    if (info is DirectoryInfo d)
                     {
-                        log.Warning("Skipping symlink directory to prevent infinite recursion: {DirectoryName}", d.FullName);
-                        continue;
+                        // Prevent infinite recursion / DoS from symlinks looping back to parents
+                        if ((d.Attributes & FileAttributes.ReparsePoint) != 0)
+                        {
+                            log.Warning("Skipping symlink directory to prevent infinite recursion: {DirectoryName}", d.FullName);
+                            continue;
+                        }
+                        directories.Add(new HdlgDirectory(d, false, true, log));
                     }
-                    directories.Add(new HdlgDirectory(d, false, true, log));
+                    else if (info is FileInfo f)
+                    {
+                        var properties = propertyBrowser.GetFileProperty(f.FullName);
+                        var file = new HdlgFile(f, properties);
+                        files.Add(file);
+                    }
                 }
                 directories.Sort();
             }
-
-            foreach (var f in directoryInfo.EnumerateFiles())
+            else
             {
-                var properties = propertyBrowser.GetFileProperty(f.FullName);
-                var file = new HdlgFile(f, properties);
-                files.Add(file);
+                foreach (var f in directoryInfo.EnumerateFiles())
+                {
+                    var properties = propertyBrowser.GetFileProperty(f.FullName);
+                    var file = new HdlgFile(f, properties);
+                    files.Add(file);
+                }
             }
             files.Sort();
 

--- a/benchmark.csx
+++ b/benchmark.csx
@@ -1,2 +1,0 @@
-using System.Diagnostics;
-// Script to run a test or benchmark


### PR DESCRIPTION
💡 What: Replaced separate consecutive calls to `EnumerateDirectories()` and `EnumerateFiles()` with a single pass loop using `EnumerateFileSystemInfos()` in `HdlgDirectory.cs` and `BrowserForm.cs`.
🎯 Why: Calling both enumeration methods separately forces the OS and .NET framework to scan the directory contents twice. In hot loops like a deep recursive folder scan or heavy UI initialization, this doubles I/O overhead.
📊 Impact: Cuts file system directory enumeration overhead by half in `BrowserForm_BeforeExpand` and recursive scans in `HdlgDirectory.Browse()`.
🔬 Measurement: Verified compilation with `dotnet build` and ensured logic handles `DirectoryInfo` vs `FileInfo` identically to the previous version.

---
*PR created automatically by Jules for task [9859585053651339205](https://jules.google.com/task/9859585053651339205) started by @bestter*