### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Defense in Depth for File Execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -43,3 +43,8 @@
 **Vulnerability:** While XSS vulnerabilities in HTML exports were previously mitigated via `WebUtility.HtmlEncode`, relying solely on encoding can be brittle if future changes introduce unencoded output paths.
 **Learning:** Static HTML exports should use a restrictive Content Security Policy (CSP) to ensure scripts cannot be executed and data cannot be exfiltrated, even if an XSS vulnerability is introduced later.
 **Prevention:** Add a strict CSP meta tag (`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none';">`) to all generated HTML exports.
+
+## 2026-06-05 - [MOTW Bypass via Container/Shortcut Extensions]
+**Vulnerability:** Container files (like .iso, .img, .vhd) and shortcut/theme files bypass Mark of the Web (MOTW) and can lead to arbitrary code execution if opened automatically.
+**Learning:** Certain extensions not traditionally considered executables (e.g., .iso, .url, .theme) can be abused by attackers to bypass security warnings and execute code.
+**Prevention:** Always include MOTW-bypass and container extensions in blocklists when directly launching user-supplied files via `Process.Start`.

--- a/HDLG winforms/MainWindow.cs
+++ b/HDLG winforms/MainWindow.cs
@@ -202,7 +202,8 @@ toolStripStatusLabelTotalTime.Visible = false;
 		private static readonly HashSet<string> DangerousExtensions = new( StringComparer.OrdinalIgnoreCase )
 		{
 			".exe", ".bat", ".cmd", ".ps1", ".vbs", ".js", ".wsf", ".scr", ".com", ".msi", ".pif", ".hta", ".cpl",
-			".jar", ".reg", ".lnk", ".msc", ".vbe", ".jse", ".scf", ".ws", ".wsh"
+			".jar", ".reg", ".lnk", ".msc", ".vbe", ".jse", ".scf", ".ws", ".wsh",
+			".iso", ".img", ".vhd", ".vhdx", ".url", ".appref-ms", ".theme", ".themepack"
 		};
 
 		/// <summary>


### PR DESCRIPTION
## 🛡️ Sentinel Security Enhancement

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** MOTW Bypass. Container files (.iso, .img, .vhd) and certain Windows shortcut or theme variants (.url, .theme) can be used by attackers to deliver malware that bypasses Windows' Mark of the Web (MOTW) protections when automatically opened or mounted. 
🎯 **Impact:** If a user generates a directory list of an untrusted folder (e.g. downloads) and double clicks a malicious ISO or theme file from within the app, Windows might launch/mount it without security warnings, leading to code execution.
🔧 **Fix:** Added `.iso`, `.img`, `.vhd`, `.vhdx`, `.url`, `.appref-ms`, `.theme`, and `.themepack` to the `DangerousExtensions` blocklist inside `MainWindow.cs`.
✅ **Verification:** Verify that opening an `.iso` file from the UI now displays an access denied error. Test suite passes.

---
*PR created automatically by Jules for task [8279773877461736532](https://jules.google.com/task/8279773877461736532) started by @bestter*