### PR TITLE
🛡️ Sentinel: [HIGH] Fix XML DoS via unhandled invalid characters in export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -43,3 +43,8 @@
 **Vulnerability:** While XSS vulnerabilities in HTML exports were previously mitigated via `WebUtility.HtmlEncode`, relying solely on encoding can be brittle if future changes introduce unencoded output paths.
 **Learning:** Static HTML exports should use a restrictive Content Security Policy (CSP) to ensure scripts cannot be executed and data cannot be exfiltrated, even if an XSS vulnerability is introduced later.
 **Prevention:** Add a strict CSP meta tag (`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none';">`) to all generated HTML exports.
+
+## 2024-06-01 - [XML DoS via Unhandled Control Characters in Export]
+**Vulnerability:** Found an issue where the XML export function in `DirectoryBrowser.cs` could crash if file metadata (such as an MP3 tag) contained characters that are invalid in XML (e.g., spaces in element names like "Camera Model", or control characters in the content).
+**Learning:** `XmlWriter` throws an unhandled exception if it attempts to write invalid element names or values, causing the entire directory export to fail. This constitutes a Denial of Service via malformed third-party files.
+**Prevention:** When generating XML with `XmlWriter` using untrusted data, encode element keys with `XmlConvert.EncodeLocalName()` and sanitize values with a custom method that filters out invalid XML control characters.

--- a/HDLG winforms/DirectoryBrowser.cs
+++ b/HDLG winforms/DirectoryBrowser.cs
@@ -174,14 +174,15 @@ namespace HDLG_winforms
 				{
 					if (!string.IsNullOrWhiteSpace( property.Key ) && property.Value != null)
 					{
+						string encodedKey = XmlConvert.EncodeLocalName( property.Key ) ?? "UnknownProperty";
 						if (property.Value is DateTime dtValue)
 						{
-							await writer.WriteElementStringAsync( null, property.Key, null, dtValue.ToString( "O", CultureInfo.InvariantCulture ) ).ConfigureAwait( false );
+							await writer.WriteElementStringAsync( null, encodedKey, null, dtValue.ToString( "O", CultureInfo.InvariantCulture ) ).ConfigureAwait( false );
 						}
 						else
 						{
 							var value = property.Value.ToString( CultureInfo.InvariantCulture );
-							await writer.WriteElementStringAsync( null, property.Key, null, value ).ConfigureAwait( false );
+							await writer.WriteElementStringAsync( null, encodedKey, null, SanitizeXmlString(value) ).ConfigureAwait( false );
 						}
 					}
 				}
@@ -189,6 +190,34 @@ namespace HDLG_winforms
 			}
 
 			await writer.WriteEndElementAsync( ).ConfigureAwait( false );
+		}
+
+		private static string SanitizeXmlString(string? xml)
+		{
+			if (string.IsNullOrEmpty(xml))
+			{
+				return xml ?? string.Empty;
+			}
+
+			StringBuilder sb = new StringBuilder(xml.Length);
+			foreach (char c in xml)
+			{
+				if (IsLegalXmlChar(c))
+				{
+					sb.Append(c);
+				}
+			}
+			return sb.ToString();
+		}
+
+		private static bool IsLegalXmlChar(int character)
+		{
+			return character == 0x9 /* == '\t' == 9   */          ||
+				   character == 0xA /* == '\n' == 10  */          ||
+				   character == 0xD /* == '\r' == 13  */          ||
+				  (character >= 0x20    && character <= 0xD7FF  ) ||
+				  (character >= 0xE000  && character <= 0xFFFD  ) ||
+				  (character >= 0x10000 && character <= 0x10FFFF);
 		}
 		#endregion
 

--- a/HDLG.Tests/DirectoryBrowserTests.cs
+++ b/HDLG.Tests/DirectoryBrowserTests.cs
@@ -82,6 +82,50 @@ namespace HDLG.Tests
         }
 
         [Fact]
+        public async Task SaveAsXMLAsync_FileWithInvalidXmlCharacters_SanitizesAndSucceeds()
+        {
+            // Arrange
+            var testFilePath = Path.Combine(baseDirectoryPath, "badxml.mp3");
+            System.IO.File.WriteAllText(testFilePath, "dummy");
+
+            var properties = new System.Collections.Generic.Dictionary<string, IConvertible>
+            {
+                { "Camera Model", "Nikon" }, // Space is invalid in XML element name
+                { "InvalidVal", "Test\x0BText" } // \x0B is invalid XML character
+            };
+
+            var browserMock = new Mock<HdlgFileProperty.FilePropertyBrowser>(loggerMock.Object, new HdlgFileProperty.IFilePropertyGetter[0]);
+            browserMock.Setup(b => b.GetFileProperty(testFilePath)).Returns(properties);
+
+            var dir = new HdlgDirectory(baseDirectoryPath, true, false, loggerMock.Object);
+            dir.Browse(browserMock.Object);
+
+            var xmlPath = Path.Combine(Path.GetTempPath(), "test_badxml_" + Guid.NewGuid().ToString() + ".xml");
+
+            try
+            {
+                // Act
+                await directoryBrowser.SaveAsXMLAsync(xmlPath, dir);
+
+                // Assert
+                System.IO.File.Exists(xmlPath).Should().BeTrue();
+
+                var xmlContent = await System.IO.File.ReadAllTextAsync(xmlPath);
+
+                // Should use encoded local name for 'Camera Model'
+                xmlContent.Should().Contain("<Camera_x0020_Model>Nikon</Camera_x0020_Model>");
+
+                // Should sanitize value by removing the invalid XML character (\x0B)
+                xmlContent.Should().Contain("<InvalidVal>TestText</InvalidVal>");
+            }
+            finally
+            {
+                if (System.IO.File.Exists(xmlPath))
+                    System.IO.File.Delete(xmlPath);
+            }
+        }
+
+        [Fact]
         public async Task SaveAsHTMLAsync_NullFilePath_ThrowsArgumentException()
         {
             await Assert.ThrowsAsync<ArgumentException>(() => directoryBrowser.SaveAsHTMLAsync(null!, testDirectory));

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,1 +1,1 @@
-dotnet test
+dotnet test HDLG.sln -p:EnableWindowsTargeting=true


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XmlWriter throws an exception and halts the entire XML export process when encountering invalid XML element names (e.g. spaces in properties like "Camera Model") or invalid control characters in metadata values (like `\x0B` in an MP3 tag).
🎯 Impact: An attacker or a malformed third-party file could cause a Denial of Service (DoS) for the application's XML export feature.
🔧 Fix:
- Encoded XML element names using `System.Xml.XmlConvert.EncodeLocalName()`.
- Added a custom `SanitizeXmlString` method to filter out invalid XML characters based on the XML 1.0 standard.
- Added tests in `DirectoryBrowserTests.cs` to ensure the export succeeds even with bad metadata.
✅ Verification: Ran `dotnet test HDLG.sln` to ensure the new tests pass and manual verification confirms the fix works.

---
*PR created automatically by Jules for task [10792486069825771644](https://jules.google.com/task/10792486069825771644) started by @bestter*