### PR TITLE
🧪 Add tests for FilePropertyBrowser.LogGetterStatistics

### DIFF
--- a/HDLG.Tests/FilePropertyBrowserTests.cs
+++ b/HDLG.Tests/FilePropertyBrowserTests.cs
@@ -5,6 +5,7 @@ using HdlgFileProperty;
 using Moq;
 using Serilog;
 using Xunit;
+using System.Globalization;
 
 namespace HDLG.Tests
 {
@@ -117,7 +118,7 @@ namespace HDLG.Tests
 
             // Assert
             // It should only log the total files line, which is 0
-            loggerMock.Verify(l => l.Information(It.Is<string>(s => s.Contains("Total number of files 0"))), Times.Once);
+            loggerMock.Verify(l => l.Information("Total number of files {TotalNumberOfFiles}", 0L), Times.Once);
         }
 
         [Fact]
@@ -135,8 +136,15 @@ namespace HDLG.Tests
             browser.LogGetterStatistics();
 
             // Assert
-            loggerMock.Verify(l => l.Information(It.Is<string>(s => s.Contains("total runtime"))), Times.Once);
-            loggerMock.Verify(l => l.Information(It.Is<string>(s => s.Contains("Total number of files 1"))), Times.Once);
+            loggerMock.Verify(l => l.Information(
+                "{PropertyGetterType} total runtime: {TotalExecutionTime}. Number of files: {TotalFiles}. Average: {AverageTime}",
+                propertyGetterMock1.Object.GetType(),
+                It.IsAny<string>(), // TotalExecutionTime
+                1L, // TotalFiles
+                It.IsAny<string>() // AverageTime
+            ), Times.Once);
+
+            loggerMock.Verify(l => l.Information("Total number of files {TotalNumberOfFiles}", 1L), Times.Once);
         }
     }
 }

--- a/HDLG.Tests/HDLG.Tests.csproj
+++ b/HDLG.Tests/HDLG.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/pr.txt
+++ b/pr.txt
@@ -1,9 +1,5 @@
-🧪 Add tests for PdfPropertyGetter.GetFileProperties
+🧪 Add tests for FilePropertyBrowser.LogGetterStatistics
 
-🎯 **What:** Added tests for the untesteted `GetFileProperties` method in `PdfPropertyGetter.cs`
-📊 **Coverage:** Covered multiple scenarios:
-    - Reading a valid PDF with a title.
-    - Reading a valid PDF without a title.
-    - Trying to read a nonexistent file (logs Error).
-    - Trying to read an invalid PDF format (logs Warning).
-✨ **Result:** Test coverage improved with the required happy path, missing properties handling, and exception handling paths.
+🎯 **What:** Corrected and enhanced tests for `FilePropertyBrowser.LogGetterStatistics`.
+📊 **Coverage:** Adjusted the test to verify Serilog structured logging matches the template and parameters exactly for `LogGetterStatistics_FilesProcessed_LogsAveragesAndTotal` and `LogGetterStatistics_NoFilesProcessed_DoesNotLogAverages`.
+✨ **Result:** Test correctly asserts exact log template match in `LogGetterStatistics`, improving test assertions and verifying correct behaviour.


### PR DESCRIPTION
🎯 **What:** Corrected and enhanced tests for `FilePropertyBrowser.LogGetterStatistics`.
📊 **Coverage:** Adjusted the test to verify Serilog structured logging matches the template and parameters exactly for `LogGetterStatistics_FilesProcessed_LogsAveragesAndTotal` and `LogGetterStatistics_NoFilesProcessed_DoesNotLogAverages`.
✨ **Result:** Test correctly asserts exact log template match in `LogGetterStatistics`, improving test assertions and verifying correct behaviour.

---
*PR created automatically by Jules for task [8375941892164769385](https://jules.google.com/task/8375941892164769385) started by @bestter*