### PR TITLE
🛡️ Sentinel: [HIGH] Fix DLL hijacking vulnerability in Process.Start

### DIFF
--- a/HDLG winforms/MainWindow.cs
+++ b/HDLG winforms/MainWindow.cs
@@ -232,7 +232,8 @@ toolStripStatusLabelTotalTime.Visible = false;
 			using Process fileopener = new( );
 			fileopener.StartInfo = new ProcessStartInfo( path )
 			{
-				UseShellExecute = true
+				UseShellExecute = true,
+				WorkingDirectory = Environment.GetFolderPath( Environment.SpecialFolder.System )
 			};
 			fileopener.Start( );
 		}


### PR DESCRIPTION
**Severity:** HIGH
**Vulnerability:** The application was vulnerable to DLL hijacking when launching user files via `Process.Start` with `UseShellExecute = true` because it did not explicitly set a safe `WorkingDirectory`.
**Impact:** A spawned process could load malicious DLLs from the untrusted directory containing the target file, leading to arbitrary code execution.
**Fix:** Explicitly set `fileopener.StartInfo.WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.System)` before calling `Process.Start`.
**Verification:** Run `dotnet build` and `dotnet test`. Verified logic is correct and code compiles.

---
*PR created automatically by Jules for task [15375463051248179570](https://jules.google.com/task/15375463051248179570) started by @bestter*