### PR TITLE
⚡ Bolt: Merge consecutive directory loops during Browse

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,6 @@
 ## 2024-05-15 - Loop Fusion in Directory Traversal
 **Learning:** Consecutive `foreach` loops iterating over the same list (like aggregating totals from subdirectories) cause unnecessary redundant iteration and increase overhead, especially on deep or wide folder hierarchies.
 **Action:** When aggregating multiple independent properties from a collection of objects, fuse the loops and calculate all aggregates in a single iteration pass over the collection to immediately halve the loop iteration time.
+## 2024-06-02 - Merge consecutive directory loops during Browse
+**Learning:** Traversing the same collection in multiple, consecutive loops can be combined to reduce O(N) overhead iterations, lowering instruction counts and cache misses especially when processing thousands of entries recursively.
+**Action:** Always combine loops iterating over the same collection doing independent sub-tasks if doing so does not compromise readability.

--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HDLG winforms\HDLG winforms.csproj" />
+    <ProjectReference Include="..\HDLG file property\HdlgFileProperty.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="4.3.1" />
+  </ItemGroup>
+</Project>

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using HDLG_winforms;
+using HdlgFileProperty;
+using Serilog;
+
+namespace Benchmark
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Starting benchmark...");
+
+            // Setup Serilog
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Error() // keep it quiet
+                .CreateLogger();
+
+            string testDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "HdlgBenchmark");
+            if (System.IO.Directory.Exists(testDir))
+            {
+                System.IO.Directory.Delete(testDir, true);
+            }
+            System.IO.Directory.CreateDirectory(testDir);
+
+            CreateTree(testDir, 4, 5);
+
+            var propertyBrowser = new FilePropertyBrowser(Log.Logger);
+
+            // Warmup
+            var warmupDir = new HdlgDirectory(testDir, true, true, Log.Logger);
+            warmupDir.Browse(propertyBrowser);
+
+            int iterations = 10;
+            long totalMs = 0;
+
+            for (int i = 0; i < iterations; i++)
+            {
+                var dir = new HdlgDirectory(testDir, true, true, Log.Logger);
+                var sw = Stopwatch.StartNew();
+                dir.Browse(propertyBrowser);
+                sw.Stop();
+                totalMs += sw.ElapsedMilliseconds;
+                Console.WriteLine($"Iteration {i}: {sw.ElapsedMilliseconds} ms (Dirs: {dir.TotalDirectories}, Files: {dir.TotalFiles})");
+            }
+
+            Console.WriteLine($"Average: {totalMs / (double)iterations} ms");
+
+            System.IO.Directory.Delete(testDir, true);
+        }
+
+        static void CreateTree(string root, int depth, int branches)
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                System.IO.File.WriteAllText(System.IO.Path.Combine(root, $"file_{i}.txt"), "test");
+            }
+
+            if (depth == 0) return;
+
+            for (int i = 0; i < branches; i++)
+            {
+                var dir = System.IO.Path.Combine(root, $"dir_{i}");
+                System.IO.Directory.CreateDirectory(dir);
+                CreateTree(dir, depth - 1, branches);
+            }
+        }
+    }
+}

--- a/HDLG winforms/HdlgDirectory.cs
+++ b/HDLG winforms/HdlgDirectory.cs
@@ -114,16 +114,13 @@ namespace HDLG_winforms
             }
             files.Sort();
 
-            foreach (HdlgDirectory d in directories)
-            {
-                d.Browse(propertyBrowser);
-            }
-
             // Compute subtree totals once (post-order) so export counts become O(1) with no extra recursion.
             TotalDirectories = directories.Count;
             TotalFiles = files.Count;
+
             foreach (HdlgDirectory d in directories)
             {
+                d.Browse(propertyBrowser);
                 TotalDirectories += d.TotalDirectories;
                 TotalFiles += d.TotalFiles;
             }

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,26 @@
+<<<<<<< SEARCH
+            foreach (HdlgDirectory d in directories)
+            {
+                d.Browse(propertyBrowser);
+            }
+
+            // Compute subtree totals once (post-order) so export counts become O(1) with no extra recursion.
+            TotalDirectories = directories.Count;
+            TotalFiles = files.Count;
+            foreach (HdlgDirectory d in directories)
+            {
+                TotalDirectories += d.TotalDirectories;
+                TotalFiles += d.TotalFiles;
+            }
+=======
+            // Compute subtree totals once (post-order) so export counts become O(1) with no extra recursion.
+            TotalDirectories = directories.Count;
+            TotalFiles = files.Count;
+
+            foreach (HdlgDirectory d in directories)
+            {
+                d.Browse(propertyBrowser);
+                TotalDirectories += d.TotalDirectories;
+                TotalFiles += d.TotalFiles;
+            }
+>>>>>>> REPLACE

--- a/pr.txt
+++ b/pr.txt
@@ -1,5 +1,3 @@
-🧪 Add tests for FilePropertyBrowser.LogGetterStatistics
-
-🎯 **What:** Corrected and enhanced tests for `FilePropertyBrowser.LogGetterStatistics`.
-📊 **Coverage:** Adjusted the test to verify Serilog structured logging matches the template and parameters exactly for `LogGetterStatistics_FilesProcessed_LogsAveragesAndTotal` and `LogGetterStatistics_NoFilesProcessed_DoesNotLogAverages`.
-✨ **Result:** Test correctly asserts exact log template match in `LogGetterStatistics`, improving test assertions and verifying correct behaviour.
+💡 **What:** Merged two consecutive loops over `directories` inside `HdlgDirectory.Browse()`. The first loop traversed `directories` to recursively call `.Browse()`, and the immediate following loop traversed the same collection to sum `TotalDirectories` and `TotalFiles`. These are now computed in a single iteration.
+🎯 **Why:** To eliminate the CPU and iterator overhead of traversing the collection a second time, especially noticeable in deeply nested directory structures with a high count of folders.
+📊 **Measured Improvement:** No direct baseline was collected due to execution constraints in the provided Linux environment lacking `Microsoft.WindowsDesktop.App` runtime for benchmarking WinForms. However, this optimization reduces N iterator steps to 0 extra overhead by combining logic into an existing O(N) loop.

--- a/run_benchmark.csx
+++ b/run_benchmark.csx
@@ -1,0 +1,3 @@
+#r "HDLG winforms/bin/Debug/net10.0-windows10.0.26100.0/HTML directory list generator.dll"
+#r "HDLG file property/bin/Debug/net10.0-windows10.0.26100.0/HdlgFileProperty.dll"
+// ... C# script is not an option as per memory: The `dotnet-script` tool is not installed in the execution environment.

--- a/run_patch.py
+++ b/run_patch.py
@@ -1,0 +1,21 @@
+import sys
+
+def apply_patch(file_path, patch_file):
+    with open(patch_file, 'r') as f:
+        patch_text = f.read()
+
+    search_block = patch_text.split('<<<<<<< SEARCH')[1].split('=======')[0].strip('\n')
+    replace_block = patch_text.split('=======')[1].split('>>>>>>> REPLACE')[0].strip('\n')
+
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    if search_block in content:
+        new_content = content.replace(search_block, replace_block)
+        with open(file_path, 'w') as f:
+            f.write(new_content)
+        print("Patch applied successfully.")
+    else:
+        print("Error: Search block not found in file.")
+
+apply_patch("HDLG winforms/HdlgDirectory.cs", "patch.diff")


### PR DESCRIPTION
💡 **What:** Merged two consecutive loops over `directories` inside `HdlgDirectory.Browse()`. The first loop traversed `directories` to recursively call `.Browse()`, and the immediate following loop traversed the same collection to sum `TotalDirectories` and `TotalFiles`. These are now computed in a single iteration.
🎯 **Why:** To eliminate the CPU and iterator overhead of traversing the collection a second time, especially noticeable in deeply nested directory structures with a high count of folders.
📊 **Measured Improvement:** No direct baseline was collected due to execution constraints in the provided Linux environment lacking `Microsoft.WindowsDesktop.App` runtime for benchmarking WinForms. However, this optimization reduces N iterator steps to 0 extra overhead by combining logic into an existing O(N) loop.

---
*PR created automatically by Jules for task [17539246827176154471](https://jules.google.com/task/17539246827176154471) started by @bestter*