### PR TITLE
⚡ Bolt: Fast-path XML string sanitization to reduce GC allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,7 @@
 ## 2024-05-19 - Merging Loops for Aggregate Counts
 **Learning:** Merging consecutive iterations of the same collection, when their side-effects are independent (e.g. aggregating distinct running totals), yields significant and immediate CPU/time savings with minimal code alteration.
 **Action:** Always inspect subsequent loops to identify identical iteration sets and, when logic allows, fold their inner contents into a single unified pass.
+
+## 2024-05-24 - Fast-Pathing String Sanitization to Avoid Allocations
+**Learning:** In string sanitization routines (like removing invalid XML characters), eagerly allocating a `StringBuilder` for every string causes significant garbage collection overhead, particularly because most strings (e.g., standard file paths) do not contain invalid characters.
+**Action:** When writing sanitization or validation methods, always scan the string first to find the first invalid character. If none are found, return the original string immediately. Only allocate a `StringBuilder` and perform character-by-character appending if an invalid character is actually detected.

--- a/HDLG winforms/DirectoryBrowser.cs
+++ b/HDLG winforms/DirectoryBrowser.cs
@@ -199,12 +199,32 @@ namespace HDLG_winforms
 				return xml ?? string.Empty;
 			}
 
-			StringBuilder sb = new StringBuilder(xml.Length);
-			foreach (char c in xml)
+			// Performance optimization: Fast-path for valid strings to avoid StringBuilder allocation.
+			// Most XML strings (paths, names) are valid, so scanning first saves significant memory overhead.
+			int firstIllegalCharIndex = -1;
+			for (int i = 0; i < xml.Length; i++)
 			{
-				if (IsLegalXmlChar(c))
+				if (!IsLegalXmlChar(xml[i]))
 				{
-					sb.Append(c);
+					firstIllegalCharIndex = i;
+					break;
+				}
+			}
+
+			// If no invalid characters are found, immediately return the original string.
+			if (firstIllegalCharIndex == -1)
+			{
+				return xml;
+			}
+
+			// Only allocate StringBuilder if sanitization is actually required.
+			StringBuilder sb = new StringBuilder(xml.Length);
+			sb.Append(xml, 0, firstIllegalCharIndex);
+			for (int i = firstIllegalCharIndex + 1; i < xml.Length; i++)
+			{
+				if (IsLegalXmlChar(xml[i]))
+				{
+					sb.Append(xml[i]);
 				}
 			}
 			return sb.ToString();

--- a/run_benchmark.csx
+++ b/run_benchmark.csx
@@ -1,3 +1,0 @@
-#r "HDLG winforms/bin/Debug/net10.0-windows10.0.26100.0/HTML directory list generator.dll"
-#r "HDLG file property/bin/Debug/net10.0-windows10.0.26100.0/HdlgFileProperty.dll"
-// ... C# script is not an option as per memory: The `dotnet-script` tool is not installed in the execution environment.


### PR DESCRIPTION
### 💡 What
Modified `SanitizeXmlString` in `DirectoryBrowser.cs` to fast-path strings that contain no invalid XML characters. Instead of immediately allocating a `StringBuilder`, the method now scans the string first. If no invalid character is found, it immediately returns the original string.

### 🎯 Why
During XML serialization (which occurs for every file and directory exported), `SanitizeXmlString` was unconditionally allocating a `StringBuilder` matching the length of the string and appending characters one by one. Because the vast majority of exported strings (file paths, names, normal timestamps) do not contain invalid control characters, this resulted in massive, unnecessary garbage collection overhead and CPU cycles in a hot path.

### 📊 Impact
* **Memory Allocation:** Reduces `StringBuilder` allocations from O(N) to roughly O(1) during typical execution, where N is the number of file properties and paths serialized.
* **Performance:** Reduces CPU time spent processing completely valid strings by avoiding the allocation and copy loop overhead.

### 🔬 Measurement
Run a directory generation process for a large folder hierarchy containing standard files. Monitor the memory allocation and garbage collection frequency using a .NET profiler (e.g., dotMemory or the Visual Studio Diagnostic Tools). You will observe significantly fewer allocations originating from `SanitizeXmlString`.

---
*PR created automatically by Jules for task [9563658004772857773](https://jules.google.com/task/9563658004772857773) started by @bestter*