### PR TITLE
🛡️ Sentinel: [Low] Fix DLL hijacking risk in credit.cs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -53,3 +53,8 @@
 **Vulnerability:** Found an issue where the XML export function in `DirectoryBrowser.cs` could crash if file metadata (such as an MP3 tag) contained characters that are invalid in XML (e.g., spaces in element names like "Camera Model", or control characters in the content).
 **Learning:** `XmlWriter` throws an unhandled exception if it attempts to write invalid element names or values, causing the entire directory export to fail. This constitutes a Denial of Service via malformed third-party files.
 **Prevention:** When generating XML with `XmlWriter` using untrusted data, encode element keys with `XmlConvert.EncodeLocalName()` and sanitize values with a custom method that filters out invalid XML control characters.
+
+## 2026-06-05 - [DLL Hijacking via Missing WorkingDirectory]
+**Vulnerability:** Found `Process.Start` calls opening external URLs via `UseShellExecute = true` without explicitly setting the `WorkingDirectory`.
+**Learning:** If an application launches an external process without specifying a safe working directory, and the current working directory happens to point to an untrusted location, it may be vulnerable to DLL search order hijacking when the target process launches.
+**Prevention:** To prevent DLL hijacking vulnerabilities when launching files via `Process.Start` with `UseShellExecute = true`, always explicitly set `WorkingDirectory` to a safe, trusted location (like `Environment.GetFolderPath(Environment.SpecialFolder.System)`).

--- a/HDLG winforms/credit.cs
+++ b/HDLG winforms/credit.cs
@@ -35,7 +35,8 @@ namespace HDLG_winforms
 			ProcessStartInfo psInfo = new( )
 			{
 				FileName = "https://www.flaticon.com/free-icons/root-directory",
-				UseShellExecute = true
+				UseShellExecute = true,
+				WorkingDirectory = Environment.GetFolderPath( Environment.SpecialFolder.System )
 			};
 			Process.Start( psInfo );
 
@@ -46,7 +47,8 @@ namespace HDLG_winforms
 			ProcessStartInfo psInfo = new( )
 			{
 				FileName = "https://www.gnu.org/licenses/gpl-3.0.en.html",
-				UseShellExecute = true
+				UseShellExecute = true,
+				WorkingDirectory = Environment.GetFolderPath( Environment.SpecialFolder.System )
 			};
 			Process.Start( psInfo );
 		}
@@ -57,7 +59,8 @@ namespace HDLG_winforms
 			ProcessStartInfo psInfo = new( )
 			{
 				FileName = "https://www.gnu.org/licenses/gpl-3.0.en.html",
-				UseShellExecute = true
+				UseShellExecute = true,
+				WorkingDirectory = Environment.GetFolderPath( Environment.SpecialFolder.System )
 			};
 			Process.Start( psInfo );
 		}


### PR DESCRIPTION
**Severity:** LOW
**Vulnerability:** The application used `Process.Start` with `UseShellExecute = true` to launch external URLs in `credit.cs` without explicitly setting the `WorkingDirectory`.
**Impact:** If the application's current working directory happened to be set to an untrusted or user-controlled folder, launching the default browser could inadvertently load malicious DLLs from that untrusted location (DLL search order hijacking).
**Fix:** Added `WorkingDirectory = Environment.GetFolderPath( Environment.SpecialFolder.System )` to the `ProcessStartInfo` initializations in `credit.cs` as a defense-in-depth measure, matching the secure pattern already used in `MainWindow.OpenWithDefaultProgram`.
**Verification:** Run `dotnet build -p:EnableWindowsTargeting=true` and ensure there are no regressions.

---
*PR created automatically by Jules for task [305491700664666655](https://jules.google.com/task/305491700664666655) started by @bestter*