### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service in recursive directory traversal

### DIFF
--- a/HDLG winforms/HdlgDirectory.cs
+++ b/HDLG winforms/HdlgDirectory.cs
@@ -82,34 +82,56 @@ namespace HDLG_winforms
 
             if (BrowseSubdirectory)
             {
-                foreach (var info in directoryInfo.EnumerateFileSystemInfos())
+                try
                 {
-                    if (info is DirectoryInfo d)
+                    foreach (var info in directoryInfo.EnumerateFileSystemInfos())
                     {
-                        // Prevent infinite recursion / DoS from symlinks looping back to parents
-                        if ((d.Attributes & FileAttributes.ReparsePoint) != 0)
+                        if (info is DirectoryInfo d)
                         {
-                            log.Warning("Skipping symlink directory to prevent infinite recursion: {DirectoryName}", d.FullName);
-                            continue;
+                            // Prevent infinite recursion / DoS from symlinks looping back to parents
+                            if ((d.Attributes & FileAttributes.ReparsePoint) != 0)
+                            {
+                                log.Warning("Skipping symlink directory to prevent infinite recursion: {DirectoryName}", d.FullName);
+                                continue;
+                            }
+                            directories.Add(new HdlgDirectory(d, false, true, log));
                         }
-                        directories.Add(new HdlgDirectory(d, false, true, log));
+                        else if (info is FileInfo f)
+                        {
+                            var properties = propertyBrowser.GetFileProperty(f.FullName);
+                            var file = new HdlgFile(f, properties);
+                            files.Add(file);
+                        }
                     }
-                    else if (info is FileInfo f)
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    log.Warning(ex, "Access denied to directory: {Path}", Path);
+                }
+                catch (System.Security.SecurityException ex)
+                {
+                    log.Warning(ex, "Security error accessing directory: {Path}", Path);
+                }
+                directories.Sort();
+            }
+            else
+            {
+                try
+                {
+                    foreach (var f in directoryInfo.EnumerateFiles())
                     {
                         var properties = propertyBrowser.GetFileProperty(f.FullName);
                         var file = new HdlgFile(f, properties);
                         files.Add(file);
                     }
                 }
-                directories.Sort();
-            }
-            else
-            {
-                foreach (var f in directoryInfo.EnumerateFiles())
+                catch (UnauthorizedAccessException ex)
                 {
-                    var properties = propertyBrowser.GetFileProperty(f.FullName);
-                    var file = new HdlgFile(f, properties);
-                    files.Add(file);
+                    log.Warning(ex, "Access denied to directory: {Path}", Path);
+                }
+                catch (System.Security.SecurityException ex)
+                {
+                    log.Warning(ex, "Security error accessing directory: {Path}", Path);
                 }
             }
             files.Sort();


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When scanning a directory that contains subdirectories or files without appropriate access permissions, `DirectoryInfo.EnumerateFileSystemInfos` and `DirectoryInfo.EnumerateFiles` throw an `UnauthorizedAccessException` or `SecurityException`. If unhandled, this crashes the background scanning thread, causing a Denial of Service (DoS) for the entire export operation.
🎯 Impact: An attacker or standard system behavior (like trying to access `System Volume Information`) could completely stop the user from generating a directory list.
🔧 Fix: Wrapped the enumeration loops inside `HdlgDirectory.cs` with `try-catch` blocks that log a warning and skip the restricted directory, allowing the rest of the scan to proceed safely.
✅ Verification: Ran `dotnet build HDLG.sln` to confirm no syntax errors, and `dotnet test HDLG.sln` to confirm tests run properly.

---
*PR created automatically by Jules for task [15112277935550076735](https://jules.google.com/task/15112277935550076735) started by @bestter*