### PR TITLE
🧹 Fix formatting issue in ImagePropertyGetter

### DIFF
--- a/HDLG file property/ImagePropertyGetter.cs
+++ b/HDLG file property/ImagePropertyGetter.cs
@@ -49,7 +49,7 @@ namespace HdlgFileProperty
                     }
                 }
             }
-            catch (UnknownImageFormatException e    )
+            catch (UnknownImageFormatException e)
             {
                 //The stream does not have a valid image format.
                 Logger?.Warning(e, "Unsupported image format for file: {FilePath}", path);

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,7 @@
+🎯 **What:** Removed extra spaces in the `catch` block statement for `UnknownImageFormatException` in `ImagePropertyGetter.cs`.
+
+💡 **Why:** This is a trivial code health improvement to maintain code hygiene and readability. Extraneous spacing inside parentheses does not conform to standard C# formatting guidelines and creates unnecessary visual clutter.
+
+✅ **Verification:** Verified by ensuring the code compiles successfully (`dotnet build -p:EnableWindowsTargeting=true`). Ran `dotnet test` to confirm tests remain unaffected. The change is restricted entirely to whitespace within a catch block declaration.
+
+✨ **Result:** Improved readability and formatting consistency in `ImagePropertyGetter.cs`.


### PR DESCRIPTION
🎯 **What:** Removed extra spaces in the `catch` block statement for `UnknownImageFormatException` in `ImagePropertyGetter.cs`.

💡 **Why:** This is a trivial code health improvement to maintain code hygiene and readability. Extraneous spacing inside parentheses does not conform to standard C# formatting guidelines and creates unnecessary visual clutter.

✅ **Verification:** Verified by ensuring the code compiles successfully (`dotnet build -p:EnableWindowsTargeting=true`). Ran `dotnet test` to confirm tests remain unaffected. The change is restricted entirely to whitespace within a catch block declaration.

✨ **Result:** Improved readability and formatting consistency in `ImagePropertyGetter.cs`.

---
*PR created automatically by Jules for task [8478154990029241326](https://jules.google.com/task/8478154990029241326) started by @bestter*