### PR TITLE
🛡️ Sentinel: [Medium] Fix Fail-Open UI State Authorization Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,3 @@
-
 ## 2024-05-23 - [XSS in HTML Export]
 **Vulnerability:** Found an XSS vulnerability where user-controlled metadata like file names, directory names, and file properties were directly written to HTML report via string interpolation in DirectoryBrowser.cs.
 **Learning:** System directories and files can contain arbitrary characters, and metadata parsers extract tags that can be manipulated by an attacker to execute JS when the generated HTML is viewed.

--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -169,8 +169,6 @@ namespace HDLG_winforms
                     return;
                 }
 
-                btnOpenFile.Enabled = true;
-
                 lblSelectedFileName.Text = fileInfo.Name;
 
                 AddPropertyToListView("Name", fileInfo.Name);
@@ -189,6 +187,8 @@ namespace HDLG_winforms
                         AddPropertyToListView(kvp.Key, kvp.Value?.ToString() ?? "");
                     }
                 }
+
+                btnOpenFile.Enabled = true;
             }
 #pragma warning disable CA1031 // Ne pas attraper les types d'exception généraux
 			catch (Exception ex)


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was a "fail-open" pattern in the UI where the `btnOpenFile` button was aggressively enabled *before* completely processing and validating the file properties.

⚠️ **Risk:** The potential impact if left unfixed was an authorization bypass. An unexpected exception during the file properties validation (such as `UnauthorizedAccessException` if the file could not be read fully despite the path being checked) would leave the dangerous action (the "Open File" button) available to the user.

🛡️ **Solution:** The `btnOpenFile.Enabled = true;` statement was moved to the very end of the `try` block. This ensures all safety and property checks complete correctly without exceptions. If an error occurs during property loading, the catch block is hit and the button reliably stays disabled (`btnOpenFile.Enabled = false;` is set at the top of the method).

---
*PR created automatically by Jules for task [6714635418459990653](https://jules.google.com/task/6714635418459990653) started by @bestter*