### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Error UI

### DIFF
--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -199,12 +199,12 @@ namespace HDLG_winforms
             catch (UnauthorizedAccessException ex)
             {
                 logger.Warning(ex, "Access denied reading properties for file: {Path}", info.Path);
-                AddPropertyToListView("Error", "Access Denied: " + ex.Message);
+                AddPropertyToListView("Error", "Access Denied");
             }
             catch (SecurityException ex)
             {
                 logger.Warning(ex, "Security exception reading properties for file: {Path}", info.Path);
-                AddPropertyToListView("Error", "Access Denied: " + ex.Message);
+                AddPropertyToListView("Error", "Access Denied");
             }
 #pragma warning disable CA1031 // Ne pas attraper les types d'exception généraux
 			catch (Exception ex)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Information Disclosure via error messages. The `UnauthorizedAccessException` and `SecurityException` catch blocks in `BrowserForm.cs` appended the raw `ex.Message` to the "Access Denied" UI notification.
🎯 **Impact:** Exposing raw exception messages can leak sensitive internal details, such as absolute system paths, permission boundaries, or directory structures to an unprivileged end-user.
🔧 **Fix:** Removed `ex.Message` from the UI output (`AddPropertyToListView`), providing a generic "Access Denied" message instead, while continuing to securely log the full exception details internally via `logger.Warning()`.
✅ **Verification:** Verified via `read_file` that the UI strings no longer contain `ex.Message` and ran `dotnet test` to ensure successful compilation and no regressions.

---
*PR created automatically by Jules for task [769529108684782965](https://jules.google.com/task/769529108684782965) started by @bestter*