### PR TITLE
⚡ Bolt: Eliminate enumerator boxing allocations for IReadOnlyList in recursive exports

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -65,3 +65,7 @@
 ## 2024-05-25 - Use for loops for arrays in hot loops
 **Learning:** While iterating over an array with `foreach` is generally fast, it still incurs minor overhead for the iterator state machine and enumerator struct allocation. In a hot path (like `FilePropertyBrowser.GetFileProperty` which executes for every single file in a recursive directory scan), explicitly changing an array `foreach` to a `for (int i = 0; i < array.Length; i++)` loop eliminates this overhead completely for a measurable reduction in instruction count.
 **Action:** To strictly avoid `IEnumerator` struct allocation and iterator state machine overhead in C# hot paths, explicitly use standard `for` loops with index-based access instead of `foreach` loops when iterating over primitive arrays.
+
+## 2024-06-10 - Avoid enumerator boxing on IReadOnlyList<T> in recursive tree iterations
+**Learning:** Iterating over an `IReadOnlyList<T>` using `foreach` forces the compiler to use `IEnumerator<T>` via the interface implementation rather than a direct duck-typed struct enumerator (like `List<T>.Enumerator`), causing a heap allocation per iteration loop. In deep recursive trees (like directory structure serialization), this creates O(N) garbage allocations (where N is number of directories).
+**Action:** Always prefer `for (int i = 0; i < collection.Count; i++)` when iterating over collections typed as `IReadOnlyList<T>` or `IList<T>` in hot loops to guarantee zero enumerator allocations.

--- a/HDLG winforms/DirectoryBrowser.cs
+++ b/HDLG winforms/DirectoryBrowser.cs
@@ -122,8 +122,9 @@ namespace HDLG_winforms
 			if (directory.Directories.Count > 0)
 			{
 				await writer.WriteStartElementAsync( null, "Directories", null ).ConfigureAwait( false );
-				foreach (HdlgDirectory d in directory.Directories)
+				for (int i = 0; i < directory.Directories.Count; i++)
 				{
+					HdlgDirectory d = directory.Directories[i];
 					await WriteXmlDirectoryAsync( writer, d ).ConfigureAwait( false );
 				}
 				await writer.WriteEndElementAsync( ).ConfigureAwait( false );
@@ -132,8 +133,9 @@ namespace HDLG_winforms
 			if (directory.Files.Count > 0)
 			{
 				await writer.WriteStartElementAsync( null, "Files", null ).ConfigureAwait( false );
-				foreach (HdlgFile file in directory.Files)
+				for (int i = 0; i < directory.Files.Count; i++)
 				{
+					HdlgFile file = directory.Files[i];
 					await WriteXmlFileAsync( writer, file ).ConfigureAwait( false );
 				}
 				await writer.WriteEndElementAsync( ).ConfigureAwait( false );
@@ -390,8 +392,9 @@ namespace HDLG_winforms
 			if (directory.Directories.Count > 0)
 			{
 				var inDepth = depth + 2;
-				foreach (HdlgDirectory d in directory.Directories)
+				for (int i = 0; i < directory.Directories.Count; i++)
 				{
+					HdlgDirectory d = directory.Directories[i];
 					await WriteDirectoriesListContainAsync( writer, d, inDepth ).ConfigureAwait( false );
 				}
 
@@ -425,8 +428,9 @@ namespace HDLG_winforms
 			{
 				await writer.WriteLineAsync( spacer + "\t<div class=\"directories\">" ).ConfigureAwait( false );
 				var inDepth = depth + 1;
-				foreach (HdlgDirectory d in directory.Directories)
+				for (int i = 0; i < directory.Directories.Count; i++)
 				{
+					HdlgDirectory d = directory.Directories[i];
 					await WritHtmlDirectoryAsync( writer, d, inDepth ).ConfigureAwait( false );
 				}
 				await writer.WriteLineAsync( spacer + "\t</div>" ).ConfigureAwait( false );
@@ -435,8 +439,9 @@ namespace HDLG_winforms
 			if (directory.Files.Count > 0)
 			{
 				await writer.WriteLineAsync( spacer + "\t<div class=\"files\">" ).ConfigureAwait( false );
-				foreach (HdlgFile file in directory.Files)
+				for (int i = 0; i < directory.Files.Count; i++)
 				{
+					HdlgFile file = directory.Files[i];
 					await WriteHtmlFileAsync( writer, file, spacer + "\t" ).ConfigureAwait( false );
 				}
 				await writer.WriteLineAsync( spacer + "\t</div>" ).ConfigureAwait( false );


### PR DESCRIPTION
💡 **What**: Replaced `foreach` loops with standard index-based `for (int i = 0; i < list.Count; i++)` loops when iterating over `directory.Directories` and `directory.Files` collections (which are of type `IReadOnlyList<T>`) within `HDLG winforms/DirectoryBrowser.cs`.
🎯 **Why**: Using a `foreach` loop over an interface like `IReadOnlyList<T>` forces the C# compiler to box the internal struct enumerator into an `IEnumerator<T>` on the heap. During recursive operations (like traversing an entire file system tree for XML/HTML generation), this causes an unnecessary garbage collection allocation per directory node, adding significant memory pressure.
📊 **Impact**: Eliminates O(N) (where N is the number of directories) enumerator allocations during directory list serialization, resulting in a cleaner memory profile, lower GC overhead, and faster completion times on deeply nested directory structures.
🔬 **Measurement**: Profiling the memory allocations during HTML/XML generation on a deeply nested or highly populated directory tree will show a significant reduction in `IEnumerator` object allocations.

---
*PR created automatically by Jules for task [9842580149431347361](https://jules.google.com/task/9842580149431347361) started by @bestter*