### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in UI

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -62,3 +62,8 @@
 **Vulnerability:** Unhandled generic exceptions around `File` and `Directory` methods allowed sensitive file path information to potentially be logged or displayed when system access errors occurred.
 **Learning:** Catching specific access errors like `UnauthorizedAccessException` and `SecurityException` allows the application to gracefully degrade or report simple "Access Denied" errors, improving user experience and avoiding leaking paths.
 **Prevention:** Always catch and handle `UnauthorizedAccessException` and `SecurityException` explicitly when working with system IO operations before falling back to catching generic `Exception`.
+
+## 2026-06-08 - UI Information Disclosure
+**Vulnerability:** The application was vulnerable to Information Disclosure because a generic `catch (Exception ex)` block in `BrowserForm.cs` wrote `ex.Message` directly to the UI (a `ListView`).
+**Learning:** When file operations fail (e.g., due to system restrictions, concurrent access, or missing paths), `ex.Message` can leak sensitive system architecture details, internal paths, or stack traces to end-users.
+**Prevention:** Catch specific exceptions like `UnauthorizedAccessException` and `SecurityException` separately, and provide generic, safe error messages (like 'An unexpected error occurred.') in generic `catch (Exception ex)` handlers.

--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -211,7 +211,7 @@ namespace HDLG_winforms
 #pragma warning restore CA1031
 			{
 				logger.Error(ex, "Error reading properties for file: {Path}", info.Path);
-                AddPropertyToListView("Error", ex.Message);
+                AddPropertyToListView("Error", "An unexpected error occurred.");
             }
             finally
             {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was vulnerable to Information Disclosure because a generic `catch (Exception ex)` block in `BrowserForm.cs` wrote `ex.Message` directly to the UI. If a file operation failed, `ex.Message` could leak sensitive system architecture details, internal paths, or stack traces to end-users.
🎯 Impact: Attackers could gain insights into internal system paths or architectures.
🔧 Fix: Changed `ex.Message` to display a generic, safe string ("An unexpected error occurred.") in the UI. Error details are still preserved in `logger.Error` for secure debugging.
✅ Verification: Code builds and passes tests. Logged critical security learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11663040773686882759](https://jules.google.com/task/11663040773686882759) started by @bestter*