### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Global Error Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -67,3 +67,8 @@
 **Vulnerability:** The application was vulnerable to Information Disclosure because a generic `catch (Exception ex)` block in `BrowserForm.cs` wrote `ex.Message` directly to the UI (a `ListView`).
 **Learning:** When file operations fail (e.g., due to system restrictions, concurrent access, or missing paths), `ex.Message` can leak sensitive system architecture details, internal paths, or stack traces to end-users.
 **Prevention:** Catch specific exceptions like `UnauthorizedAccessException` and `SecurityException` separately, and provide generic, safe error messages (like 'An unexpected error occurred.') in generic `catch (Exception ex)` handlers.
+
+## 2026-06-08 - UI Information Disclosure via MessageBox in Global Error Handler
+**Vulnerability:** The application was vulnerable to Information Disclosure because the global exception handler (`AfficherMessageErreur` in `Program.cs`) appended the raw exception message (`ex.Message`) to a `MessageBox` displayed to the user when unhandled thread or background exceptions occurred.
+**Learning:** `ex.Message` for unhandled exceptions often contains sensitive system details, internal paths, connection strings, or technical states that should never be presented to an end-user, as this violates CWE-209.
+**Prevention:** In global error handlers, always log the full exception securely but provide only a generic, safe error message to the user UI (e.g., "Please check the application logs for more details.").

--- a/HDLG winforms/Program.cs
+++ b/HDLG winforms/Program.cs
@@ -106,7 +106,7 @@ namespace HDLG_winforms
 		static void AfficherMessageErreur (string messageDeBase, Exception ex)
 		{
 			log.Fatal( ex, "Global unhandled exception intercepted." );
-			string messageComplet = $"{messageDeBase}\n\nTechnical detail : {ex.Message}";
+			string messageComplet = $"{messageDeBase}\n\nPlease check the application logs for more details.";
 			MessageBox.Show( messageComplet, "Application error", MessageBoxButtons.OK, MessageBoxIcon.Error );
 		}
 	}


### PR DESCRIPTION
**🚨 Severity:** MEDIUM

**💡 Vulnerability:** Information Disclosure (CWE-209). The global exception handler (`AfficherMessageErreur` in `Program.cs`) appended the raw exception message (`ex.Message`) directly to a `MessageBox` displayed to the user when unhandled thread or background exceptions occurred.

**🎯 Impact:** `ex.Message` for unhandled exceptions often contains sensitive system details, internal paths, connection strings, or technical states that should never be presented to an end-user. This could allow an attacker to gather sensitive internal system information to aid further attacks.

**🔧 Fix:** Modified the `AfficherMessageErreur` method to display a safe, generic message ("Please check the application logs for more details.") to the user while continuing to log the full, detailed exception via Serilog for developer troubleshooting.

**✅ Verification:**
- Ensured the application builds successfully with `dotnet build -p:EnableWindowsTargeting=true`
- Ran the test suite via `dotnet test`
- Reviewed the code change to confirm technical details are preserved in the log but not in the UI string.

---
*PR created automatically by Jules for task [5471786413916750529](https://jules.google.com/task/5471786413916750529) started by @bestter*