### PR TITLE
🧹 [code health improvement] Fix formatting in ImagePropertyGetter.cs

### DIFF
--- a/HDLG file property/ImagePropertyGetter.cs
+++ b/HDLG file property/ImagePropertyGetter.cs
@@ -50,12 +50,12 @@ namespace HdlgFileProperty
 			}
 			catch (UnknownImageFormatException e)
 			{
-				//The stream does not have a valid image format.
+				// The stream does not have a valid image format.
 				Logger?.Warning(e, "Unsupported image format for file: {FilePath}", path);
 			}
 			catch (InvalidImageContentException e)
 			{
-				//The image content is corrupted or invalid.
+				// The image content is corrupted or invalid.
 				Logger?.Warning(e, "Invalid image content for file: {FilePath}", path);
 			}
 #pragma warning disable CA1031 // Ne pas intercepter les types d'exception générale


### PR DESCRIPTION
🎯 **What:** The comments inside the `catch` blocks in `ImagePropertyGetter.cs` were missing a space after the `//` which violates typical C# coding styles and visual cleanliness.
💡 **Why:** Improved readability and consistency of comments inside the catch blocks.
✅ **Verification:** Recompiled successfully with zero errors. All formatting guidelines and tests have been maintained.
✨ **Result:** Improved visual consistency in `ImagePropertyGetter.cs` without modifying any application functionality.

---
*PR created automatically by Jules for task [14744728032749430425](https://jules.google.com/task/14744728032749430425) started by @bestter*