### PR TITLE
🧪 Add test for DirectoryBrowser.SaveAsHTMLAsync File IO Exception

### DIFF
--- a/HDLG.Tests/DirectoryBrowserTests.cs
+++ b/HDLG.Tests/DirectoryBrowserTests.cs
@@ -138,6 +138,18 @@ namespace HDLG.Tests
             await Assert.ThrowsAsync<ArgumentNullException>(() => directoryBrowser.SaveAsHTMLAsync(tempHtmlFilePath, null!));
         }
 
+
+        [Fact]
+        public async Task SaveAsHTMLAsync_FileLocked_ThrowsIOException()
+        {
+            // Arrange
+            // Lock the file by opening it with exclusive access
+            using var fileStream = new FileStream(tempHtmlFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<IOException>(() => directoryBrowser.SaveAsHTMLAsync(tempHtmlFilePath, testDirectory));
+        }
+
         [Fact]
         public async Task SaveAsHTMLAsync_ValidInputs_GeneratesHtmlFile()
         {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for when `SaveAsHTMLAsync` encounters a locked file and throws an `IOException`.
📊 **Coverage:** The scenario where the target HTML file is locked by another process (using `FileShare.None`) is now explicitly tested.
✨ **Result:** Increased test coverage and confidence that the application safely surfaces the underlying `IOException` when attempting to overwrite locked output files, matching the expected behavior.

---
*PR created automatically by Jules for task [7419487775619133555](https://jules.google.com/task/7419487775619133555) started by @bestter*