### PR TITLE
🧪 [FilePropertyBrowser] Add test for Merged Properties Key Collision

### DIFF
--- a/HDLG.Tests/FilePropertyBrowserTests.cs
+++ b/HDLG.Tests/FilePropertyBrowserTests.cs
@@ -107,6 +107,33 @@ namespace HDLG.Tests
             result.Count.Should().Be(2);
         }
 
+
+        [Fact]
+        public void GetFileProperty_PathSupportedByMultipleGettersWithKeyCollision_PreservesFirstGetterValue()
+        {
+            // Arrange
+            string path = "test.document";
+            var properties1 = new Dictionary<string, IConvertible> { { "Title", "First Title" } };
+            var properties2 = new Dictionary<string, IConvertible> { { "Title", "Second Title" }, { "Author", "John Doe" } };
+
+            propertyGetterMock1.Setup(g => g.IsSupportedFile(path)).Returns(true);
+            propertyGetterMock1.Setup(g => g.GetFileProperties(path)).Returns(properties1);
+
+            propertyGetterMock2.Setup(g => g.IsSupportedFile(path)).Returns(true);
+            propertyGetterMock2.Setup(g => g.GetFileProperties(path)).Returns(properties2);
+
+            var browser = new FilePropertyBrowser(loggerMock.Object, propertyGetterMock1.Object, propertyGetterMock2.Object);
+
+            // Act
+            var result = browser.GetFileProperty(path);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().ContainKey("Title").WhoseValue.Should().Be("First Title");
+            result.Should().ContainKey("Author").WhoseValue.Should().Be("John Doe");
+            result.Count.Should().Be(2);
+        }
+
         [Fact]
         public void LogGetterStatistics_NoFilesProcessed_DoesNotLogAverages()
         {


### PR DESCRIPTION
🎯 **What:** The `GetFileProperty` method in `FilePropertyBrowser` merges property dictionaries using `TryAdd`. A test is needed to verify this behavior works correctly when multiple getters return the same property key, preserving the first one's value rather than throwing an exception.
📊 **Coverage:** A test case `GetFileProperty_PathSupportedByMultipleGettersWithKeyCollision_PreservesFirstGetterValue` has been added, increasing the edge case coverage for `FilePropertyBrowser`.
✨ **Result:** Improved test coverage for the dictionary merge logic ensuring key collisions handle correctly.

---
*PR created automatically by Jules for task [4104440085808881252](https://jules.google.com/task/4104440085808881252) started by @bestter*