### PR TITLE
🛡️ Sentinel: Medium Fix Insecure Process.Start without user confirmation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -98,3 +98,12 @@
 **Vulnerability:** Generated HTML files did not include the X-Content-Type-Options header.
 **Learning:** Browsers may attempt to MIME-sniff content if the content-type is missing or incorrectly declared by a web server. This can lead to content confusion and potential Cross-Site Scripting (XSS) if malicious content is interpreted as executable scripts.
 **Prevention:** Always add `<meta http-equiv="X-Content-Type-Options" content="nosniff">` to generated HTML exports to enforce the declared content type and reduce the risk of drive-by downloads or XSS.
+## 2026-06-22 - [Prompt User for All File Executions]
+**Vulnerability:** Even if a file is on the "safe allowlist" and executed via  with , it can execute an unknown payload or a zero-day exploit disguised as a safe format (e.g. malformed PDF).
+**Learning:** The safest approach for opening any local file out of the user's explicit interaction path (i.e. programmatically opening files via links or shortcuts, though these were UI actions) is to ensure the user is explicitly aware of the exact file path about to be opened.
+**Prevention:** When mitigating process injection via file execution in UI applications (e.g., using ), avoid relying solely on a dangerous extension blocklist. Instead, use a strict allowlist of known safe extensions, explicitly reject known dangerous extensions, and prompt the user for confirmation (e.g., via `MessageBox` displaying the full path) before opening ANY file type, even those on the safe allowlist, to ensure explicit consent.
+
+## 2024-06-25 - [Prompt User for All File Executions]
+**Vulnerability:** Even if a file is on the "safe allowlist" and executed via Process.Start with UseShellExecute = true, it can execute an unknown payload or a zero-day exploit disguised as a safe format (e.g. malformed PDF).
+**Learning:** The safest approach for opening any local file out of the user's explicit interaction path (i.e. programmatically opening files via links or shortcuts) is to ensure the user is explicitly aware of the exact file path about to be opened.
+**Prevention:** When mitigating process injection via file execution in UI applications (e.g., using Process.Start), avoid relying solely on a dangerous extension blocklist. Instead, use a strict allowlist of known safe extensions, explicitly reject known dangerous extensions, and prompt the user for confirmation (e.g., via MessageBox displaying the full path) before opening ANY file type, even those on the safe allowlist, to ensure explicit consent.

--- a/HDLG winforms/MainWindow.cs
+++ b/HDLG winforms/MainWindow.cs
@@ -251,10 +251,13 @@ toolStripStatusLabelTotalTime.Visible = false;
 			}, ext => {
 				DialogResult res = MessageBox.Show( $"The file extension '{ext}' is not in the safe allowlist.\n\nAre you sure you want to open this file?", "Security Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning );
 				return res == DialogResult.Yes;
+			}, fullPath => {
+				DialogResult res = MessageBox.Show( $"You are about to open the following file:\n\n{fullPath}\n\nAre you sure you want to continue?", "Security Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning );
+				return res == DialogResult.Yes;
 			} );
 		}
 
-		public static void OpenWithDefaultProgram (string path, Action<string> processStarter, Func<string, bool>? promptUnknownExtension = null)
+		public static void OpenWithDefaultProgram (string path, Action<string> processStarter, Func<string, bool>? promptUnknownExtension = null, Func<string, bool>? promptUser = null)
 		{
 			ArgumentNullException.ThrowIfNull( processStarter );
 			ArgumentException.ThrowIfNullOrWhiteSpace( path );
@@ -282,6 +285,11 @@ toolStripStatusLabelTotalTime.Visible = false;
 				{
 					return;
 				}
+			}
+
+			if (promptUser != null && !promptUser(fullPath))
+			{
+				return;
 			}
 
 			processStarter( fullPath );

--- a/HDLG.Tests/OpenWithDefaultProgramTests.cs
+++ b/HDLG.Tests/OpenWithDefaultProgramTests.cs
@@ -141,5 +141,29 @@ namespace HDLG.Tests
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*not allowed for security reasons*");
         }
+
+        [Fact]
+        public void OpenWithDefaultProgram_UserDeclinesPrompt_DoesNotExecute()
+        {
+            var unknownFile = System.IO.Path.Combine(tempDir, "unknown.txt");
+            System.IO.File.WriteAllText(unknownFile, "unknown content");
+
+            bool executed = false;
+            MainWindow.OpenWithDefaultProgram(unknownFile, _ => { executed = true; }, null, _ => false);
+
+            executed.Should().BeFalse();
+        }
+
+        [Fact]
+        public void OpenWithDefaultProgram_UserAcceptsPrompt_Executes()
+        {
+            var unknownFile = System.IO.Path.Combine(tempDir, "unknown.txt");
+            System.IO.File.WriteAllText(unknownFile, "unknown content");
+
+            bool executed = false;
+            MainWindow.OpenWithDefaultProgram(unknownFile, _ => { executed = true; }, null, _ => true);
+
+            executed.Should().BeTrue();
+        }
     }
 }

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,4 +1,4 @@
-💡 What: Caches the result of `WebUtility.HtmlEncode(directory.Path)` in `DirectoryBrowser.cs` inside the HTML export methods.
-🎯 Why: Reduces redundant string allocations when the same path string is printed multiple times in hot directory loops.
-📊 Impact: Decreases garbage collection overhead during HTML output generation.
-🔬 Measurement: Verify tests run properly (they fail on Linux due to WindowsDesktop.App missing, but build succeeds) and verify `HtmlEncode` is not executed multiple times for the same value.
+💡 **Vulnerability:** The application executed files (via `Process.Start` with `UseShellExecute = true`) that passed the `SafeExtensions` allowlist without explicit user confirmation.
+🎯 **Impact:** Malicious files disguised as safe formats (e.g., malformed PDF or Word documents containing macros) could be automatically executed by the system's default shell handler simply by being clicked in the application UI. This violates defense-in-depth principles.
+🔧 **Fix:** Added a new requirement to `MainWindow.OpenWithDefaultProgram` that prompts the user (via `MessageBox` indicating the full file path) and requires affirmative consent before executing *any* file, even if it has a safe extension.
+✅ **Verification:** Added two unit tests (`OpenWithDefaultProgram_UserDeclinesPrompt_DoesNotExecute` and `OpenWithDefaultProgram_UserAcceptsPrompt_Executes`) to ensure the execution action is correctly bypassed if the user declines the prompt.


### PR DESCRIPTION
💡 **Vulnerability:** The application executed files (via `Process.Start` with `UseShellExecute = true`) that passed the `SafeExtensions` allowlist without explicit user confirmation.
🎯 **Impact:** Malicious files disguised as safe formats (e.g., malformed PDF or Word documents containing macros) could be automatically executed by the system's default shell handler simply by being clicked in the application UI. This violates defense-in-depth principles.
🔧 **Fix:** Added a new requirement to `MainWindow.OpenWithDefaultProgram` that prompts the user (via `MessageBox` indicating the full file path) and requires affirmative consent before executing *any* file, even if it has a safe extension.
✅ **Verification:** Added two unit tests (`OpenWithDefaultProgram_UserDeclinesPrompt_DoesNotExecute` and `OpenWithDefaultProgram_UserAcceptsPrompt_Executes`) to ensure the execution action is correctly bypassed if the user declines the prompt.

---
*PR created automatically by Jules for task [13163809289787852732](https://jules.google.com/task/13163809289787852732) started by @bestter*