### PR TITLE
🛡️ Sentinel: Medium Fix Insecure Process.Start without user confirmation

### DIFF
--- a/HDLG winforms/MainWindow.cs
+++ b/HDLG winforms/MainWindow.cs
@@ -287,7 +287,13 @@ toolStripStatusLabelTotalTime.Visible = false;
 				}
 			}
 
-			if (promptUser != null && !promptUser(fullPath))
+			Func<string, bool> actualPromptUser = promptUser ?? (fPath =>
+			{
+				DialogResult res = MessageBox.Show( $"You are about to open the following file:\n\n{fPath}\n\nAre you sure you want to continue?", "Security Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning );
+				return res == DialogResult.Yes;
+			});
+
+			if (!actualPromptUser(fullPath))
 			{
 				return;
 			}

--- a/HDLG.Tests/OpenWithDefaultProgramTests.cs
+++ b/HDLG.Tests/OpenWithDefaultProgramTests.cs
@@ -25,21 +25,21 @@ namespace HDLG.Tests
         [Fact]
         public void OpenWithDefaultProgram_NullPath_ThrowsArgumentException()
         {
-            var act = () => MainWindow.OpenWithDefaultProgram(null!, _ => { });
+            var act = () => MainWindow.OpenWithDefaultProgram(null!, _ => { }, null, _ => true);
             act.Should().Throw<ArgumentException>();
         }
 
         [Fact]
         public void OpenWithDefaultProgram_EmptyPath_ThrowsArgumentException()
         {
-            var act = () => MainWindow.OpenWithDefaultProgram("", _ => { });
+            var act = () => MainWindow.OpenWithDefaultProgram("", _ => { }, null, _ => true);
             act.Should().Throw<ArgumentException>();
         }
 
         [Fact]
         public void OpenWithDefaultProgram_WhitespacePath_ThrowsArgumentException()
         {
-            var act = () => MainWindow.OpenWithDefaultProgram("   ", _ => { });
+            var act = () => MainWindow.OpenWithDefaultProgram("   ", _ => { }, null, _ => true);
             act.Should().Throw<ArgumentException>();
         }
 
@@ -47,7 +47,7 @@ namespace HDLG.Tests
         public void OpenWithDefaultProgram_NonExistentFile_ThrowsFileNotFoundException()
         {
             var nonExistentPath = System.IO.Path.Combine(tempDir, "nonexistent.txt");
-            var act = () => MainWindow.OpenWithDefaultProgram(nonExistentPath, _ => { });
+            var act = () => MainWindow.OpenWithDefaultProgram(nonExistentPath, _ => { }, null, _ => true);
             act.Should().Throw<FileNotFoundException>();
         }
 
@@ -92,7 +92,7 @@ namespace HDLG.Tests
             var dangerousFile = System.IO.Path.Combine(tempDir, $"malicious{extension}");
             System.IO.File.WriteAllText(dangerousFile, "dangerous content");
 
-            var act = () => MainWindow.OpenWithDefaultProgram(dangerousFile, _ => { });
+            var act = () => MainWindow.OpenWithDefaultProgram(dangerousFile, _ => { }, null, _ => true);
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*not allowed for security reasons*");
         }
@@ -117,7 +117,7 @@ namespace HDLG.Tests
 
             try
             {
-                MainWindow.OpenWithDefaultProgram(safeFile, _ => { });
+                MainWindow.OpenWithDefaultProgram(safeFile, _ => { }, null, _ => true);
             }
             catch (InvalidOperationException)
             {
@@ -137,7 +137,7 @@ namespace HDLG.Tests
             var unknownFile = System.IO.Path.Combine(tempDir, "unknown.xyz123");
             System.IO.File.WriteAllText(unknownFile, "unknown content");
 
-            var act = () => MainWindow.OpenWithDefaultProgram(unknownFile, _ => {});
+            var act = () => MainWindow.OpenWithDefaultProgram(unknownFile, _ => {}, null, _ => true);
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*not allowed for security reasons*");
         }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `Process.Start` can be executed on seemingly safe files without user confirmation, potentially executing malicious payloads.
🎯 Impact: Users might unknowingly execute malicious code disguised under safe file extensions if they click links or UI elements that trigger `Process.Start`.
🔧 Fix: Ensured `MainWindow.OpenWithDefaultProgram` always prompts for user confirmation before executing any file, providing a default `MessageBox` prompt if no custom delegate is passed, and updated tests to mock the prompt.
✅ Verification: `dotnet test` passes and execution requires explicit prompt.

---
*PR created automatically by Jules for task [2949999232162421458](https://jules.google.com/task/2949999232162421458) started by @bestter*