### PR TITLE
⚡ Bolt: Cache resolved root directory to optimize UI path traversal checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -93,3 +93,10 @@
 ## 2026-06-25 - Cache XmlConvert.EncodeLocalName results
 **Learning:** `XmlConvert.EncodeLocalName` can be relatively slow and allocates memory. In a directory browser application generating XML exports, files consistently share the same metadata property keys. Repeatedly calling this method in the hot loop for every property of every file incurs unnecessary CPU cycles and memory allocations.
 **Action:** Cache the XML-safe local name encoding in a dictionary (e.g., `_xmlEncodedPropertyKeys`) to prevent redundant string allocations and parsing operations, matching the performance pattern used for HTML outputs.
+## 2026-06-25 - Avoid Unhelpful Micro-Optimizations Involving Async/Await
+**Learning:** In C#, extracting the body of a hot loop into an `async Task` method (e.g. to avoid duplicating the loop body for a dictionary cast unboxing) introduces massive state machine overhead that completely negates any micro-optimization benefits and actively degrades performance.
+**Action:** Never sacrifice code readability or introduce async state machines in hot paths for trivial micro-optimizations (like avoiding a single enumerator allocation).
+
+## 2026-06-25 - Cache Invariant Paths in UI Components
+**Learning:** Evaluating `Path.GetFullPath(rootDirectory)` inside hot UI events (like `TreeView.BeforeExpand`) causes redundant I/O checks and string allocations. Because `rootDirectory` is invariant after construction, its resolved path can be calculated once.
+**Action:** When a UI component is bound to a specific root directory, resolve and cache its full path (with and without the trailing separator) in the constructor to optimize hot-path traversal checks.

--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -18,6 +18,8 @@ namespace HDLG_winforms
 	public partial class BrowserForm : Form
 	{
 		private readonly string rootDirectory;
+		private readonly string _resolvedRootDirectory;
+		private readonly string _resolvedRootDirectoryWithSeparator;
 		private readonly FilePropertyBrowser propertyBrowser;
 		private readonly ILogger logger;
 
@@ -27,6 +29,13 @@ namespace HDLG_winforms
 			this.rootDirectory = rootDirectory;
 			this.propertyBrowser = propertyBrowser;
 			this.logger = logger;
+
+			// Performance optimization: Cache resolved root directory strings to prevent redundant allocations and
+			// I/O operations in hot paths like IsPathWithinRoot when expanding tree nodes.
+			_resolvedRootDirectory = Path.GetFullPath(rootDirectory);
+			_resolvedRootDirectoryWithSeparator = _resolvedRootDirectory.EndsWith(Path.DirectorySeparatorChar)
+				? _resolvedRootDirectory
+				: _resolvedRootDirectory + Path.DirectorySeparatorChar;
 		}
 
         private void BrowserForm_Load(object sender, EventArgs e)
@@ -65,16 +74,9 @@ namespace HDLG_winforms
 		private bool IsPathWithinRoot (string path)
 		{
 			string resolvedPath = Path.GetFullPath( path );
-			string resolvedRoot = Path.GetFullPath( rootDirectory );
 
-			// Ensure root ends with separator for prefix comparison
-			if (!resolvedRoot.EndsWith( Path.DirectorySeparatorChar ))
-			{
-				resolvedRoot += Path.DirectorySeparatorChar;
-			}
-
-			return resolvedPath.StartsWith( resolvedRoot, StringComparison.OrdinalIgnoreCase )
-				|| string.Equals( resolvedPath, Path.GetFullPath( rootDirectory ), StringComparison.OrdinalIgnoreCase );
+			return resolvedPath.StartsWith( _resolvedRootDirectoryWithSeparator, StringComparison.OrdinalIgnoreCase )
+				|| string.Equals( resolvedPath, _resolvedRootDirectory, StringComparison.OrdinalIgnoreCase );
 		}
 
 		private void TreeView1_BeforeExpand (object sender, TreeViewCancelEventArgs e)


### PR DESCRIPTION
💡 What:
Cached the resolved root directory paths (with and without the trailing separator) in the `BrowserForm` constructor instead of dynamically evaluating `Path.GetFullPath(rootDirectory)` on every check.

🎯 Why:
`Path.GetFullPath` involves string allocations and implicit environment/directory resolution checks. Because `IsPathWithinRoot` is called heavily in UI hot paths (such as `TreeView.BeforeExpand` and `TreeView.AfterSelect`), evaluating it dynamically creates unnecessary garbage collection overhead and potential disk I/O latency. Since the `rootDirectory` does not change for the lifetime of the `BrowserForm`, caching its resolved form is safe and highly efficient.

📊 Impact:
Eliminates redundant string allocations and path resolution I/O operations per file/directory selected or expanded. Improves UI tree responsiveness during deep traversals.

🔬 Measurement:
Profile the `BrowserForm` UI tree expansion before and after. Notice the elimination of `Path.GetFullPath` calls within the `IsPathWithinRoot` hot path.

---
*PR created automatically by Jules for task [12911787732305199523](https://jules.google.com/task/12911787732305199523) started by @bestter*