### PR TITLE
🛡️ Sentinel: [Security Improvement] Add Referrer-Policy meta tag to HTML exports

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -107,3 +107,8 @@
 **Vulnerability:** Even if a file is on the "safe allowlist" and executed via Process.Start with UseShellExecute = true, it can execute an unknown payload or a zero-day exploit disguised as a safe format (e.g. malformed PDF).
 **Learning:** The safest approach for opening any local file out of the user's explicit interaction path (i.e. programmatically opening files via links or shortcuts) is to ensure the user is explicitly aware of the exact file path about to be opened.
 **Prevention:** When mitigating process injection via file execution in UI applications (e.g., using Process.Start), avoid relying solely on a dangerous extension blocklist. Instead, use a strict allowlist of known safe extensions, explicitly reject known dangerous extensions, and prompt the user for confirmation (e.g., via MessageBox displaying the full path) before opening ANY file type, even those on the safe allowlist, to ensure explicit consent.
+
+## 2026-06-25 - [Prevent Path Leakage via Referer Header]
+**Vulnerability:** Generated HTML exports of local directories lacked a `Referrer-Policy` header. If a user clicks an external link in the report (like the "Root directory icons" credit link), or if an external resource is loaded, the browser might send the full local file path (e.g., `file:///C:/Users/name/Documents/export.html`) in the HTTP `Referer` header to the external site, causing an information disclosure.
+**Learning:** Local file pathways must be protected from leakage to external domains when generating HTML files meant to be opened locally.
+**Prevention:** Always add `<meta name="referrer" content="no-referrer">` to HTML head sections generated for local offline viewing.

--- a/HDLG winforms/DirectoryBrowser.cs
+++ b/HDLG winforms/DirectoryBrowser.cs
@@ -356,6 +356,7 @@ namespace HDLG_winforms
 			await sw.WriteLineAsync( "<meta name=\"rating\" content=\"general\">" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none';\">" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( "<meta http-equiv=\"X-Content-Type-Options\" content=\"nosniff\">" ).ConfigureAwait( false );
+			await sw.WriteLineAsync( "<meta name=\"referrer\" content=\"no-referrer\">" ).ConfigureAwait( false );
 			await sw.WriteAsync( $"<title>{encodedTitle}</title>" ).ConfigureAwait( false );
 			await sw.WriteLineAsync( GetGoogleFontHeader( ) ).ConfigureAwait( false );
 			await sw.WriteLineAsync( await GetCssAsync( ).ConfigureAwait( false ) ).ConfigureAwait( false );


### PR DESCRIPTION
**💡 Vulnerability:** Generated HTML exports of local directories lacked a `Referrer-Policy` header. If a user clicks an external link in the report, or if an external resource is loaded, the browser might send the full local file path (e.g., `file:///C:/Users/name/Documents/export.html`) in the HTTP `Referer` header to the external site, causing an information disclosure.

**🎯 Impact:** Local file pathways and potentially sensitive directory structures could be leaked to external domains.

**🔧 Fix:** Added `<meta name="referrer" content="no-referrer">` to the HTML head section generated in `DirectoryBrowser.cs` to explicitly prevent the browser from sending referer information.

**✅ Verification:** Compiled and ran tests locally. Generated HTML contains the correct meta tag.

---
*PR created automatically by Jules for task [13487505489763175273](https://jules.google.com/task/13487505489763175273) started by @bestter*