### PR TITLE
⚡ Bolt: Reduce FileInfo allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -100,3 +100,7 @@
 ## 2026-06-25 - Cache Invariant Paths in UI Components
 **Learning:** Evaluating `Path.GetFullPath(rootDirectory)` inside hot UI events (like `TreeView.BeforeExpand`) causes redundant I/O checks and string allocations. Because `rootDirectory` is invariant after construction, its resolved path can be calculated once.
 **Action:** When a UI component is bound to a specific root directory, resolve and cache its full path (with and without the trailing separator) in the constructor to optimize hot-path traversal checks.
+
+## 2026-06-25 - Prevent redundant OS stat calls with FileInfo
+**Learning:** Instantiating `new FileInfo(path)` forces the OS to perform a file system stat operation to retrieve attributes. When this happens downstream inside hot loops (like `GetFileProperty` or `IsFileSizeWithinLimit` checking every file yielded by `DirectoryInfo.EnumerateFiles()`), it causes massive I/O overhead and completely bypasses the pre-populated attributes already returned by the directory enumeration.
+**Action:** Always accept and pass the existing `FileInfo` or `FileSystemInfo` object through the method chain instead of string paths whenever possible to eliminate redundant OS calls and object allocations.

--- a/HDLG file property/FilePropertyBrowser.cs
+++ b/HDLG file property/FilePropertyBrowser.cs
@@ -57,6 +57,13 @@ namespace HdlgFileProperty
 		public virtual IReadOnlyDictionary<string, IConvertible>? GetFileProperty(string path)
 		{
 			ArgumentException.ThrowIfNullOrWhiteSpace(path);
+			return GetFileProperty(new FileInfo(path));
+		}
+
+		public virtual IReadOnlyDictionary<string, IConvertible>? GetFileProperty(FileInfo fileInfo)
+		{
+			ArgumentNullException.ThrowIfNull(fileInfo);
+			string path = fileInfo.FullName;
 			TotalNumberOfFiles++;
 
 			IReadOnlyDictionary<string, IConvertible>? firstProperties = null;
@@ -68,7 +75,7 @@ namespace HdlgFileProperty
 				var propertyGetters = filePropertyGetters[i];
 				if (propertyGetters.FilePropertyGetter.IsSupportedFile(path))
 				{
-					fileSizeAllowed ??= IsFileSizeWithinLimit(path);
+					fileSizeAllowed ??= IsFileSizeWithinLimit(fileInfo);
 					if (fileSizeAllowed == false)
 					{
 						continue;
@@ -107,11 +114,10 @@ namespace HdlgFileProperty
 			return mergedProperties ?? firstProperties;
 		}
 
-		private bool IsFileSizeWithinLimit(string path)
+		private bool IsFileSizeWithinLimit(FileInfo fileInfo)
 		{
 			try
 			{
-				var fileInfo = new FileInfo(path);
 				if (!fileInfo.Exists)
 				{
 					return true;
@@ -124,13 +130,13 @@ namespace HdlgFileProperty
 						"File exceeds maximum allowed size ({MaxFileSizeBytes} bytes, actual {ActualFileSizeBytes} bytes), skipping property extraction: {FilePath}",
 						maxFileSizeBytes,
 						fileLength,
-						path);
+						fileInfo.FullName);
 					return false;
 				}
 			}
 			catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
 			{
-				logger.Warning(ex, "Cannot determine file size, skipping property extraction: {FilePath}", path);
+				logger.Warning(ex, "Cannot determine file size, skipping property extraction: {FilePath}", fileInfo.FullName);
 				return false;
 			}
 

--- a/HDLG winforms/Directory.cs
+++ b/HDLG winforms/Directory.cs
@@ -71,7 +71,7 @@ namespace HDLG_winforms
 
 			foreach (var f in directoryInfo.EnumerateFiles( ))
 			{
-				var properties = propertyBrowser.GetFileProperty( f.FullName );
+				var properties = propertyBrowser.GetFileProperty( f );
 				var file = new File( f.FullName, properties ?? System.Collections.ObjectModel.ReadOnlyDictionary<string, IConvertible>.Empty );
 				files.Add( file );
 			}

--- a/HDLG winforms/HdlgDirectory.cs
+++ b/HDLG winforms/HdlgDirectory.cs
@@ -98,7 +98,7 @@ namespace HDLG_winforms
 						}
 						else if (info is FileInfo f)
 						{
-							var properties = propertyBrowser.GetFileProperty( f.FullName );
+							var properties = propertyBrowser.GetFileProperty( f );
 							var file = new HdlgFile( f, properties );
 							files.Add( file );
 						}
@@ -120,7 +120,7 @@ namespace HDLG_winforms
 				{
 					foreach (var f in directoryInfo.EnumerateFiles( ))
 					{
-						var properties = propertyBrowser.GetFileProperty( f.FullName );
+						var properties = propertyBrowser.GetFileProperty( f );
 						var file = new HdlgFile( f, properties );
 						files.Add( file );
 					}

--- a/HDLG.Tests/FilePropertyBrowserTests.cs
+++ b/HDLG.Tests/FilePropertyBrowserTests.cs
@@ -55,7 +55,7 @@ namespace HDLG.Tests
             var browser = new FilePropertyBrowser(loggerMock.Object, propertyGetterMock1.Object);
 
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => browser.GetFileProperty(null!));
+            Assert.Throws<ArgumentNullException>(() => browser.GetFileProperty((string)null!));
             Assert.Throws<ArgumentException>(() => browser.GetFileProperty(""));
             Assert.Throws<ArgumentException>(() => browser.GetFileProperty("   "));
         }


### PR DESCRIPTION
### 💡 What
Added `FileInfo` overloads for `GetFileProperty` and `IsFileSizeWithinLimit` in `FilePropertyBrowser.cs`. Refactored the directory enumeration loops in `HdlgDirectory.cs` and `Directory.cs` to pass the existing `FileInfo` yielded by `EnumerateFiles()` instead of passing the string path.

### 🎯 Why
Previously, the hot loops would pass a string path into `GetFileProperty`, which would then instantiate a `new FileInfo(path)` just to check if the file size exceeded the processing limits. Instantiating a new `FileInfo` from a string forces the OS to perform a redundant file system `stat` call, completely ignoring the fact that the OS *already* provided those attributes during the directory enumeration.

### 📊 Impact
*   **Massive reduction in File I/O:** Eliminates one entirely redundant OS `stat` call for *every single supported file* encountered during a directory scan.
*   **Reduced GC Pressure:** Prevents the allocation of an extra `FileInfo` object per file.
*   **Faster Scans:** Directory processing times will be noticeably faster, especially on network drives or slower HDDs where `stat` calls are expensive.

### 🔬 Measurement
Run a directory scan with HTML or XML export on a deeply nested folder with thousands of files (e.g., a music or photo library). Profile the execution time and CPU/IO usage before and after. The time spent in `IsFileSizeWithinLimit` should drop to effectively zero, as it's now just a simple property read from an existing object in memory.

---
*PR created automatically by Jules for task [9600428645253129743](https://jules.google.com/task/9600428645253129743) started by @bestter*