### PR TITLE
🧪 [testing improvement] Add missing tests for ImagePropertyGetter

### DIFF
--- a/HDLG.Tests/ImagePropertyGetterTests.cs
+++ b/HDLG.Tests/ImagePropertyGetterTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using HdlgFileProperty;
+using Moq;
+using Serilog;
+using Xunit;
+
+namespace HDLG.Tests
+{
+    public class ImagePropertyGetterTests : IDisposable
+    {
+        private readonly Mock<ILogger> loggerMock;
+
+        public ImagePropertyGetterTests()
+        {
+            loggerMock = new Mock<ILogger>();
+            ImageSetup.CreateImages();
+        }
+
+        public void Dispose()
+        {
+            var files = new[]
+            {
+                "test.jpg",
+                "test_no_exif.jpg",
+                "test.png",
+                "test_invalid.jpg",
+                "test_corrupted.png",
+                "test_valid_exif.jpg",
+                "test_valid_no_exif.jpg",
+                "test_corrupted.jpg"
+            };
+
+            foreach (var file in files)
+            {
+                if (File.Exists(file))
+                {
+                    try { File.Delete(file); } catch { }
+                }
+            }
+        }
+
+        [Fact]
+        public void ImagePropertyGetter_GetFileProperties_ValidFileWithExif_ReturnsProperties()
+        {
+            // Arrange
+            var getter = new ImagePropertyGetter();
+
+            // Act
+            var properties = getter.GetFileProperties("test_valid_exif.jpg");
+
+            // Assert
+            properties.Should().ContainKey("Width");
+            properties["Width"].Should().Be(50);
+            properties.Should().ContainKey("Height");
+            properties["Height"].Should().Be(100);
+            properties.Should().ContainKey("CameraModel");
+            properties["CameraModel"].Should().Be("TestCameraModel");
+        }
+
+        [Fact]
+        public void ImagePropertyGetter_GetFileProperties_ValidFileNoExif_ReturnsPropertiesWithoutCameraModel()
+        {
+            // Arrange
+            var getter = new ImagePropertyGetter();
+
+            // Act
+            var properties = getter.GetFileProperties("test_valid_no_exif.jpg");
+
+            // Assert
+            properties.Should().ContainKey("Width");
+            properties["Width"].Should().Be(50);
+            properties.Should().ContainKey("Height");
+            properties["Height"].Should().Be(100);
+            properties.Should().NotContainKey("CameraModel");
+        }
+
+        [Fact]
+        public void ImagePropertyGetter_GetFileProperties_ValidPng_ReturnsProperties()
+        {
+            // Arrange
+            var getter = new ImagePropertyGetter();
+
+            // Act
+            var properties = getter.GetFileProperties("test.png");
+
+            // Assert
+            properties.Should().ContainKey("Width");
+            properties["Width"].Should().Be(1);
+            properties.Should().ContainKey("Height");
+            properties["Height"].Should().Be(1);
+        }
+
+        [Fact]
+        public void ImagePropertyGetter_GetFileProperties_InvalidFile_LogsWarningAndReturnsEmpty()
+        {
+            // Arrange
+            var getter = new ImagePropertyGetter();
+            getter.AddLogger(loggerMock.Object);
+
+            // Act
+            var properties = getter.GetFileProperties("test_invalid.jpg");
+
+            // Assert
+            properties.Should().BeEmpty();
+            loggerMock.Verify(l => l.Warning(It.IsAny<Exception>(), "Unsupported image format for file: {FilePath}", "test_invalid.jpg"), Times.Once);
+        }
+
+        [Fact]
+        public void ImagePropertyGetter_GetFileProperties_CorruptedImage_LogsWarningAndReturnsEmpty()
+        {
+            // Arrange
+            var getter = new ImagePropertyGetter();
+            getter.AddLogger(loggerMock.Object);
+
+            // Act
+            var properties = getter.GetFileProperties("test_corrupted.jpg");
+
+            // Assert
+            properties.Should().BeEmpty();
+            loggerMock.Verify(l => l.Warning(It.IsAny<Exception>(), "Invalid image content for file: {FilePath}", "test_corrupted.jpg"), Times.Once);
+        }
+
+        [Fact]
+        public void ImagePropertyGetter_GetFileProperties_FileNotFound_LogsWarningAndReturnsEmpty()
+        {
+            // Arrange
+            var getter = new ImagePropertyGetter();
+            getter.AddLogger(loggerMock.Object);
+
+            // Act
+            var properties = getter.GetFileProperties("nonexistent_image.jpg");
+
+            // Assert
+            properties.Should().BeEmpty();
+            loggerMock.Verify(l => l.Warning(It.IsAny<Exception>(), "Cannot read properties from file: {FilePath}", "nonexistent_image.jpg"), Times.Once);
+        }
+
+        [Theory]
+        [InlineData("test.jpg", true)]
+        [InlineData("test.jpeg", true)]
+        [InlineData("test.png", true)]
+        [InlineData("test.gif", true)]
+        [InlineData("test.bmp", true)]
+        [InlineData("test.webp", true)]
+        [InlineData("test.tiff", true)]
+        [InlineData("test.dds", true)]
+        [InlineData("test.qoi", true)]
+        [InlineData("test.txt", false)]
+        [InlineData("test.mp3", false)]
+        [InlineData("", false)]
+        [InlineData("test_no_extension", false)]
+        public void ImagePropertyGetter_IsSupportedFile_ReturnsExpectedResult(string path, bool expected)
+        {
+            // Arrange
+            var getter = new ImagePropertyGetter();
+
+            // Act
+            var result = getter.IsSupportedFile(path);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,10 +1,5 @@
-⚡ Optimize HTML encoding in DirectoryBrowser
+🧪 [testing improvement] Add missing tests for ImagePropertyGetter
 
-💡 What:
-Introduced a `Dictionary<string, string>` cache in `DirectoryBrowser` to store the HTML-encoded strings of file property keys (e.g., 'Width', 'Height', 'CameraModel'). When `SaveHtmlAsync` is called and properties are looped over, it will now check the cache first before performing `WebUtility.HtmlEncode`.
-
-🎯 Why:
-File property keys are highly repetitive within a directory. Calling `WebUtility.HtmlEncode` inside nested loops for each file and every property incurs unnecessary CPU cycles and memory allocations for generating new strings. Caching the encoded strings prevents redundant work and improves the HTML report generation performance.
-
-📊 Measured Improvement:
-A benchmark comparing the original approach (encoding on every iteration) vs. the cached approach showed an execution time improvement of ~4% per operation (`~204.0us` vs `~195.6us`), confirming the net positive performance impact while producing identical HTML output.
+🎯 What: Added a complete test suite for `ImagePropertyGetter`.
+📊 Coverage: Tested valid images with/without EXIF data, a valid PNG, corrupted files, nonexistent files, and unsupported formats.
+✨ Result: `ImagePropertyGetter` is now properly covered, completing the work started with `ImageSetup.cs`.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,6 +1,5 @@
-🎯 **What:** Extended test coverage for `ImagePropertyGetter` to specifically test `InvalidImageContentException` mapping. Removed static image generation using `ImageSharp` during tests and replaced it with dynamic Base64 fixture loading.
+🧪 Add missing tests for ImagePropertyGetter
 
-📊 **Coverage:** The base codebase already contained tests for `ImagePropertyGetter.GetFileProperties` testing valid EXIF metadata, non-EXIF, and completely broken missing files. However, `InvalidImageContentException` (which occurs when a file has a valid image header but corrupted content) was completely untested.
-This patch adds `ImagePropertyGetter_GetFileProperties_CorruptedImageContent_LogsWarningAndReturnsEmpty` to verify this missing exception path by dynamically decoding a purposefully corrupted JPEG fixture containing garbage bytes after a valid header.
-
-✨ **Result:** Addressed the testing review feedback. `ImagePropertyGetter` now successfully resolves full coverage over exception edge cases and safe fixture setup without introducing destructive filesystem behavior.
+🎯 What: Added a complete test suite for `ImagePropertyGetter`.
+📊 Coverage: Tested valid images with/without EXIF data, a valid PNG, corrupted files, nonexistent files, and unsupported formats.
+✨ Result: `ImagePropertyGetter` is now properly covered, completing the work started with `ImageSetup.cs`.

--- a/pr_title.txt
+++ b/pr_title.txt
@@ -1,1 +1,1 @@
-🛡️ Sentinel: Medium Fix Insecure Process.Start without user confirmation
+🧪 [testing improvement] Add missing tests for ImagePropertyGetter


### PR DESCRIPTION
🎯 What: Added a complete test suite for `ImagePropertyGetter`.
📊 Coverage: Tested valid images with/without EXIF data, a valid PNG, corrupted files, nonexistent files, and unsupported formats. 
✨ Result: `ImagePropertyGetter` is now properly covered, completing the work started with `ImageSetup.cs`.

---
*PR created automatically by Jules for task [9005778705142731754](https://jules.google.com/task/9005778705142731754) started by @bestter*