### PR TITLE
🧹 Code health: Flatten deeply nested conditionals in WriteXmlFileAsync

### DIFF
--- a/HDLG winforms/DirectoryBrowser.cs
+++ b/HDLG winforms/DirectoryBrowser.cs
@@ -172,72 +172,73 @@ namespace HDLG_winforms
 			await writer.WriteElementStringAsync( null, "CreationTime", null, file.CreationTime.ToString( "O", CultureInfo.InvariantCulture ) ).ConfigureAwait( false );
 
 
-			if (file.Properties != null)
+			if (file.Properties == null)
 			{
-				await writer.WriteStartElementAsync( null, "ExtentedProperties", null ).ConfigureAwait( false );
-
-				// Performance optimization: Type-check and cast IReadOnlyDictionary to Dictionary to allow
-				// the foreach loop to use the struct-based enumerator, preventing interface boxing allocations.
-				if (file.Properties is Dictionary<string, IConvertible> dictProperties)
-				{
-					foreach (var property in dictProperties)
-					{
-						if (!string.IsNullOrWhiteSpace( property.Key ) && property.Value != null)
-						{
-							if (!_xmlEncodedPropertyKeys.TryGetValue( property.Key, out string? encodedKey ))
-							{
-								encodedKey = XmlConvert.EncodeLocalName( property.Key ) ?? "UnknownProperty";
-								_xmlEncodedPropertyKeys[property.Key] = encodedKey;
-							}
-
-							if (property.Value is DateTime dtValue)
-							{
-								await writer.WriteElementStringAsync( null, encodedKey, null, dtValue.ToString( "O", CultureInfo.InvariantCulture ) ).ConfigureAwait( false );
-							}
-							else if (property.Value is sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal)
-							{
-								var value = property.Value.ToString( CultureInfo.InvariantCulture );
-								await writer.WriteElementStringAsync( null, encodedKey, null, value ).ConfigureAwait( false );
-							}
-							else
-							{
-								var value = property.Value.ToString( CultureInfo.InvariantCulture );
-								await writer.WriteElementStringAsync( null, encodedKey, null, SanitizeXmlString( value ) ).ConfigureAwait( false );
-							}
-						}
-					}
-				}
-				else
-				{
-					foreach (var property in file.Properties)
-					{
-						if (!string.IsNullOrWhiteSpace( property.Key ) && property.Value != null)
-						{
-							if (!_xmlEncodedPropertyKeys.TryGetValue( property.Key, out string? encodedKey ))
-							{
-								encodedKey = XmlConvert.EncodeLocalName( property.Key ) ?? "UnknownProperty";
-								_xmlEncodedPropertyKeys[property.Key] = encodedKey;
-							}
-
-							if (property.Value is DateTime dtValue)
-							{
-								await writer.WriteElementStringAsync( null, encodedKey, null, dtValue.ToString( "O", CultureInfo.InvariantCulture ) ).ConfigureAwait( false );
-							}
-							else if (property.Value is sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal)
-							{
-								var value = property.Value.ToString( CultureInfo.InvariantCulture );
-								await writer.WriteElementStringAsync( null, encodedKey, null, value ).ConfigureAwait( false );
-							}
-							else
-							{
-								var value = property.Value.ToString( CultureInfo.InvariantCulture );
-								await writer.WriteElementStringAsync( null, encodedKey, null, SanitizeXmlString( value ) ).ConfigureAwait( false );
-							}
-						}
-					}
-				}
 				await writer.WriteEndElementAsync( ).ConfigureAwait( false );
+				return;
 			}
+
+			await writer.WriteStartElementAsync( null, "ExtentedProperties", null ).ConfigureAwait( false );
+
+			// Performance optimization: Type-check and cast IReadOnlyDictionary to Dictionary to allow
+			// the foreach loop to use the struct-based enumerator, preventing interface boxing allocations.
+			if (file.Properties is Dictionary<string, IConvertible> dictProperties)
+			{
+				foreach (var property in dictProperties)
+				{
+					if (string.IsNullOrWhiteSpace( property.Key ) || property.Value == null) continue;
+
+					if (!_xmlEncodedPropertyKeys.TryGetValue( property.Key, out string? encodedKey ))
+					{
+						encodedKey = XmlConvert.EncodeLocalName( property.Key ) ?? "UnknownProperty";
+						_xmlEncodedPropertyKeys[property.Key] = encodedKey;
+					}
+
+					if (property.Value is DateTime dtValue)
+					{
+						await writer.WriteElementStringAsync( null, encodedKey, null, dtValue.ToString( "O", CultureInfo.InvariantCulture ) ).ConfigureAwait( false );
+					}
+					else if (property.Value is sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal)
+					{
+						var value = property.Value.ToString( CultureInfo.InvariantCulture );
+						await writer.WriteElementStringAsync( null, encodedKey, null, value ).ConfigureAwait( false );
+					}
+					else
+					{
+						var value = property.Value.ToString( CultureInfo.InvariantCulture );
+						await writer.WriteElementStringAsync( null, encodedKey, null, SanitizeXmlString( value ) ).ConfigureAwait( false );
+					}
+				}
+			}
+			else
+			{
+				foreach (var property in file.Properties)
+				{
+					if (string.IsNullOrWhiteSpace( property.Key ) || property.Value == null) continue;
+
+					if (!_xmlEncodedPropertyKeys.TryGetValue( property.Key, out string? encodedKey ))
+					{
+						encodedKey = XmlConvert.EncodeLocalName( property.Key ) ?? "UnknownProperty";
+						_xmlEncodedPropertyKeys[property.Key] = encodedKey;
+					}
+
+					if (property.Value is DateTime dtValue)
+					{
+						await writer.WriteElementStringAsync( null, encodedKey, null, dtValue.ToString( "O", CultureInfo.InvariantCulture ) ).ConfigureAwait( false );
+					}
+					else if (property.Value is sbyte or byte or short or ushort or int or uint or long or ulong or float or double or decimal)
+					{
+						var value = property.Value.ToString( CultureInfo.InvariantCulture );
+						await writer.WriteElementStringAsync( null, encodedKey, null, value ).ConfigureAwait( false );
+					}
+					else
+					{
+						var value = property.Value.ToString( CultureInfo.InvariantCulture );
+						await writer.WriteElementStringAsync( null, encodedKey, null, SanitizeXmlString( value ) ).ConfigureAwait( false );
+					}
+				}
+			}
+			await writer.WriteEndElementAsync( ).ConfigureAwait( false );
 
 			await writer.WriteEndElementAsync( ).ConfigureAwait( false );
 		}

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,11 @@
+🎯 **What:**
+Refactored `WriteXmlFileAsync` in `HDLG winforms/DirectoryBrowser.cs` to eliminate deeply nested conditionals.
+
+💡 **Why:**
+The method previously contained multiple levels of nested `if` statements (checking `if (file.Properties != null)` and then within `foreach` loops checking `if (!string.IsNullOrWhiteSpace( property.Key ) && property.Value != null)`). This indentation drift made the code difficult to read. By employing early returns (`if (file.Properties == null) { return; }`) and loop continuations (`if (string.IsNullOrWhiteSpace(...) || property.Value == null) continue;`), we organically flatten the code structure without introducing performance-degrading overhead from async helper method extractions.
+
+✅ **Verification:**
+I verified that the XML structures generated (`ExtentedProperties` node, its children, and the enclosing `File` tags) are perfectly preserved. No logic was altered, only the flow control structures were inverted. A successful local compilation was achieved (and UI tests pass up to their known limit on Linux environments).
+
+✨ **Result:**
+The refactored code is significantly easier to read, maintain, and reason about without altering the behavior of the XML generation logic.


### PR DESCRIPTION
🎯 **What:** 
Refactored `WriteXmlFileAsync` in `HDLG winforms/DirectoryBrowser.cs` to eliminate deeply nested conditionals. 

💡 **Why:**
The method previously contained multiple levels of nested `if` statements (checking `if (file.Properties != null)` and then within `foreach` loops checking `if (!string.IsNullOrWhiteSpace( property.Key ) && property.Value != null)`). This indentation drift made the code difficult to read. By employing early returns (`if (file.Properties == null) { return; }`) and loop continuations (`if (string.IsNullOrWhiteSpace(...) || property.Value == null) continue;`), we organically flatten the code structure without introducing performance-degrading overhead from async helper method extractions.

✅ **Verification:** 
I verified that the XML structures generated (`ExtentedProperties` node, its children, and the enclosing `File` tags) are perfectly preserved. No logic was altered, only the flow control structures were inverted. A successful local compilation was achieved.

✨ **Result:**
The refactored code is significantly easier to read, maintain, and reason about without altering the behavior of the XML generation logic.

---
*PR created automatically by Jules for task [10813683450886311974](https://jules.google.com/task/10813683450886311974) started by @bestter*