### PR TITLE
⚡ Bolt: Prevent UI thread blocking during TreeView directory enumeration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -117,3 +117,7 @@
 ## 2026-06-25 - Avoid FileInfo instantiation in IsSupportedFile and GetFileProperties
 **Learning:** During property extraction, passing string paths to `IFilePropertyGetter.IsSupportedFile` and `GetFileProperties` causes redundant `FileInfo` instantiations within the getters (e.g. to check `.Length` or `.Exists`), triggering unnecessary OS stat calls. When processing thousands of files, this creates significant I/O and CPU overhead. Additionally, when using Moq to match `FileInfo` objects in tests, `f.FullName` returns absolute paths, which will fail to match relative paths like `"test.jpg"` used in unit tests.
 **Action:** Update interfaces and getters to accept the existing `FileInfo` object yielded by the directory enumerator. Update test mocks to use `f.Name == path` when verifying relative paths against `FileInfo` arguments.
+
+## 2024-07-03 - Prevent UI Thread Blocking for TreeView Expand
+**Learning:** Performing directory enumeration synchronously in WinForms `TreeView.BeforeExpand` events causes the application UI to freeze completely, especially when dealing with large nested directories or slow network drives.
+**Action:** Always wrap heavy I/O operations (like `dirInfo.EnumerateFileSystemInfos()`) inside `await Task.Run(...)` in a UI event handler, change the handler to `async void`, and append `.ConfigureAwait(true)` to ensure that the continuation logic (such as populating the UI control) resumes smoothly on the main UI thread without causing layout thrashing or unresponsiveness.

--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -82,7 +82,7 @@ namespace HDLG_winforms
 				|| string.Equals( resolvedPath, _resolvedRootDirectory, StringComparison.OrdinalIgnoreCase );
 		}
 
-		private void TreeView1_BeforeExpand (object sender, TreeViewCancelEventArgs e)
+		private async void TreeView1_BeforeExpand (object sender, TreeViewCancelEventArgs e)
 		{
 			if (e.Node == null || e.Node.Tag is not NodeInfo info || !info.IsDirectory)
 				return;
@@ -101,27 +101,51 @@ namespace HDLG_winforms
 						return;
 					}
 
-					var dirInfo = new DirectoryInfo( info.Path );
+					// Performance optimization: Offload expensive I/O directory enumeration to a background thread
+					// to prevent blocking the WinForms UI thread, significantly improving perceived performance
+					// and preventing layout freezes during folder expansion.
+					var (dirInfos, fileInfos) = await Task.Run(() =>
+					{
+						var dirInfo = new DirectoryInfo( info.Path );
 
+						var dirs = new List<DirectoryInfo>( );
+						var files = new List<FileInfo>( );
+
+						foreach (var fsInfo in dirInfo.EnumerateFileSystemInfos( ))
+						{
+							if (fsInfo is DirectoryInfo dir)
+							{
+								if ((dir.Attributes & FileAttributes.ReparsePoint) != 0) continue;
+								dirs.Add( dir );
+							}
+							else if (fsInfo is FileInfo file)
+							{
+								files.Add( file );
+							}
+						}
+
+						return (dirs, files);
+					}).ConfigureAwait(true);
+
+					// Safe WinForms practice: construct TreeNodes on the UI thread after I/O is complete
 					var dirNodes = new List<TreeNode>( );
 					var fileNodes = new List<TreeNode>( );
 
-					foreach (var fsInfo in dirInfo.EnumerateFileSystemInfos( ))
+					for (int i = 0; i < dirInfos.Count; i++)
 					{
-						if (fsInfo is DirectoryInfo dir)
-						{
-							if ((dir.Attributes & FileAttributes.ReparsePoint) != 0) continue;
-							var node = new TreeNode( dir.Name );
-							node.Tag = new NodeInfo { IsDirectory = true, Path = dir.FullName };
-							node.Nodes.Add( new TreeNode( "Loading..." ) );
-							dirNodes.Add( node );
-						}
-						else if (fsInfo is FileInfo file)
-						{
-							var node = new TreeNode( file.Name );
-							node.Tag = new NodeInfo { IsDirectory = false, Path = file.FullName };
-							fileNodes.Add( node );
-						}
+						var dir = dirInfos[i];
+						var node = new TreeNode( dir.Name );
+						node.Tag = new NodeInfo { IsDirectory = true, Path = dir.FullName };
+						node.Nodes.Add( new TreeNode( "Loading..." ) );
+						dirNodes.Add( node );
+					}
+
+					for (int i = 0; i < fileInfos.Count; i++)
+					{
+						var file = fileInfos[i];
+						var node = new TreeNode( file.Name );
+						node.Tag = new NodeInfo { IsDirectory = false, Path = file.FullName };
+						fileNodes.Add( node );
 					}
 
                     e.Node.TreeView?.BeginUpdate();

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,8 +1,7 @@
-💡 **What:**
-In `DirectoryBrowser.cs`, I replaced all calls to the static wrapper methods `DirectoriesCount( directory )` and `FilesCount( directory )` with their direct underlying property counterparts `directory.TotalDirectories` and `directory.TotalFiles`. I subsequently deleted those wrapper methods entirely.
+💡 What: Refactored the `TreeView1_BeforeExpand` event handler in `BrowserForm.cs` to use `async void` and offload synchronous directory enumeration (`dirInfo.EnumerateFileSystemInfos()`) to a background thread using `await Task.Run(...)`. Constructing the `TreeNode` elements is then done safely on the main thread after awaiting the task with `.ConfigureAwait(true)`.
 
-🎯 **Why:**
-The wrapper methods `DirectoriesCount` and `FilesCount` did nothing except return the `directory.TotalDirectories` and `directory.TotalFiles` properties. While this seems trivial, C# method invocation overhead can slightly pile up, especially when traversing and serializing large, deeply nested directory hierarchies containing thousands of nodes. Accessing these cached metrics directly ensures zero unnecessary wrapper calls are pushed onto the stack.
+🎯 Why: Synchronous disk I/O in UI event handlers blocks the WinForms message pump. When expanding a directory with many files or one located on a slow network share, the entire application would freeze, causing layout thrashing and a poor user experience.
 
-📊 **Measured Improvement:**
-Since this is a straightforward static logic change substituting two direct property lookups, performance testing inside my Ubuntu testbench framework revealed it was slightly structurally faster inside deep benchmarks, although precise microbenchmarking results were difficult to strictly quantify given typical IO bounds when dealing with file systems; however, the instruction load and IL generation size strictly decrease.
+📊 Impact: Significantly improves UI responsiveness. The application will no longer freeze or show the "Not Responding" state during deep folder expansions in the Explorer view. Memory overhead is strictly contained by keeping object creation local to the `Task`.
+
+🔬 Measurement: Compile and run the application. Browse to a large directory (e.g., `C:\Windows\System32` or a slow network drive) via the internal UI Explorer (`btnStartUi_Click`). Click to expand a heavily populated folder. The tree node will display "Loading..." while the background thread fetches files without freezing the application UI, and the node will populate instantly once complete.


### PR DESCRIPTION
💡 What: Refactored the `TreeView1_BeforeExpand` event handler in `BrowserForm.cs` to use `async void` and offload synchronous directory enumeration (`dirInfo.EnumerateFileSystemInfos()`) to a background thread using `await Task.Run(...)`. Constructing the `TreeNode` elements is then done safely on the main thread after awaiting the task with `.ConfigureAwait(true)`.

🎯 Why: Synchronous disk I/O in UI event handlers blocks the WinForms message pump. When expanding a directory with many files or one located on a slow network share, the entire application would freeze, causing layout thrashing and a poor user experience.

📊 Impact: Significantly improves UI responsiveness. The application will no longer freeze or show the "Not Responding" state during deep folder expansions in the Explorer view. Memory overhead is strictly contained by keeping object creation local to the `Task`.

🔬 Measurement: Compile and run the application. Browse to a large directory (e.g., `C:\Windows\System32` or a slow network drive) via the internal UI Explorer (`btnStartUi_Click`). Click to expand a heavily populated folder. The tree node will display "Loading..." while the background thread fetches files without freezing the application UI, and the node will populate instantly once complete.

---
*PR created automatically by Jules for task [16832416290522432393](https://jules.google.com/task/16832416290522432393) started by @bestter*