### PR TITLE
⚡ Bolt: Optimize TreeView population using AddRange

### DIFF
--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -149,14 +149,8 @@ namespace HDLG_winforms
 					}
 
                     e.Node.TreeView?.BeginUpdate();
-                    for (int i = 0; i < dirNodes.Count; i++)
-                    {
-                        e.Node.Nodes.Add(dirNodes[i]);
-                    }
-                    for (int i = 0; i < fileNodes.Count; i++)
-                    {
-                        e.Node.Nodes.Add(fileNodes[i]);
-                    }
+                    e.Node.Nodes.AddRange(dirNodes.ToArray());
+                    e.Node.Nodes.AddRange(fileNodes.ToArray());
                     e.Node.TreeView?.EndUpdate();
                 }
                 catch (UnauthorizedAccessException ex)


### PR DESCRIPTION
💡 **What:** Replaced individual `e.Node.Nodes.Add()` calls inside `for` loops with `e.Node.Nodes.AddRange(dirNodes.ToArray())` and `e.Node.Nodes.AddRange(fileNodes.ToArray())`.

🎯 **Why:** Instead of invoking `Add()` for every single file and directory, using `AddRange` significantly reduces multiple layout operations and events—even within a `BeginUpdate/EndUpdate` block. This reduces overhead and speeds up rendering of nodes on large directories.

📊 **Measured Improvement:** While a custom WinForms benchmarking script was created to measure the exact milliseconds difference, we encountered an issue executing WinForms applications on the Linux test environment (`Microsoft.WindowsDesktop.App` missing). However, conceptually and according to standard WinForms best practices, `AddRange` avoids internal collection modification checks and redundant redraw events per element, resulting in faster rendering.

---
*PR created automatically by Jules for task [5751666001648557503](https://jules.google.com/task/5751666001648557503) started by @bestter*