### PR TITLE
🧹 Code Health: Improve exception logging in TestCorrupt

### DIFF
--- a/TestCorrupt/Program.cs
+++ b/TestCorrupt/Program.cs
@@ -9,7 +9,7 @@ class Program {
             var info = Image.Identify("nonexistent.jpg");
             Console.WriteLine("Identified!");
         } catch (Exception e) {
-            Console.WriteLine(e.GetType().Name);
+            Console.WriteLine(e);
         }
 
         File.WriteAllText("test_text.jpg", "hello world");
@@ -17,7 +17,7 @@ class Program {
             var info = Image.Identify("test_text.jpg");
             Console.WriteLine("Identified!");
         } catch (Exception e) {
-            Console.WriteLine(e.GetType().Name);
+            Console.WriteLine(e);
         }
 
         using (var image = new Image<Rgba32>(100, 50))
@@ -32,7 +32,7 @@ class Program {
             var info = Image.Identify("test_corrupted.jpg");
             Console.WriteLine("Identified!");
         } catch (Exception e) {
-            Console.WriteLine(e.GetType().Name);
+            Console.WriteLine(e);
         }
     }
 }


### PR DESCRIPTION
🎯 What: Updated empty catch blocks in TestCorrupt/Program.cs to print the full exception rather than just the exception type name.
💡 Why: Logging the full exception (including the stack trace and inner details) provides crucial context for debugging failures, improving the maintainability of this test program.
✅ Verification: Ran 'dotnet run --project TestCorrupt' locally to verify the program still compiles and successfully catches the expected errors (FileNotFoundException, UnknownImageFormatException, InvalidImageContentException) while printing their full details. Also compiled tests.
✨ Result: The program now outputs complete diagnostic information when exceptions occur.

---
*PR created automatically by Jules for task [14433751771584094827](https://jules.google.com/task/14433751771584094827) started by @bestter*