### PR TITLE
🧪 Add null edge case tests for HdlgDirectory comparison operators

### DIFF
--- a/HDLG.Tests/HdlgDirectoryTests.cs
+++ b/HDLG.Tests/HdlgDirectoryTests.cs
@@ -128,6 +128,165 @@ namespace HDLG.Tests
             dir1.Equals(dir2).Should().BeTrue();
             (dir1 == dir2).Should().BeTrue();
         }
+        [Fact]
+        public void EqualityOperator_NullLeft_ReturnsFalse()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) == dir).Should().BeFalse();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void EqualityOperator_NullRight_ReturnsFalse()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (dir == ((HdlgDirectory?)null)).Should().BeFalse();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void EqualityOperator_BothNull_ReturnsTrue()
+        {
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) == ((HdlgDirectory?)null)).Should().BeTrue();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void InequalityOperator_NullLeft_ReturnsTrue()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) != dir).Should().BeTrue();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void InequalityOperator_NullRight_ReturnsTrue()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (dir != ((HdlgDirectory?)null)).Should().BeTrue();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void InequalityOperator_BothNull_ReturnsFalse()
+        {
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) != ((HdlgDirectory?)null)).Should().BeFalse();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void LessThanOperator_NullLeft_ReturnsTrue()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) < dir).Should().BeTrue();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void LessThanOperator_NullRight_ReturnsFalse()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (dir < ((HdlgDirectory?)null)).Should().BeFalse();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void LessThanOperator_BothNull_ReturnsFalse()
+        {
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) < ((HdlgDirectory?)null)).Should().BeFalse();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void LessThanOrEqualOperator_NullLeft_ReturnsTrue()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) <= dir).Should().BeTrue();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void LessThanOrEqualOperator_NullRight_ReturnsFalse()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (dir <= ((HdlgDirectory?)null)).Should().BeFalse();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void LessThanOrEqualOperator_BothNull_ReturnsTrue()
+        {
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) <= ((HdlgDirectory?)null)).Should().BeTrue();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void GreaterThanOperator_NullLeft_ReturnsFalse()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) > dir).Should().BeFalse();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void GreaterThanOperator_NullRight_ReturnsTrue()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (dir > ((HdlgDirectory?)null)).Should().BeTrue();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void GreaterThanOperator_BothNull_ReturnsFalse()
+        {
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) > ((HdlgDirectory?)null)).Should().BeFalse();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void GreaterThanOrEqualOperator_NullLeft_ReturnsFalse()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) >= dir).Should().BeFalse();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void GreaterThanOrEqualOperator_NullRight_ReturnsTrue()
+        {
+            var dir = new HdlgDirectory(baseDirectoryPath, true, true, loggerMock.Object);
+#pragma warning disable CS8625
+            (dir >= ((HdlgDirectory?)null)).Should().BeTrue();
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void GreaterThanOrEqualOperator_BothNull_ReturnsTrue()
+        {
+#pragma warning disable CS8625
+            (((HdlgDirectory?)null) >= ((HdlgDirectory?)null)).Should().BeTrue();
+#pragma warning restore CS8625
+        }
+
+
+
+
 
         [Fact]
         public async Task Browse_UnauthorizedAccessException_LogsWarning()


### PR DESCRIPTION
🎯 **What:** The `HdlgDirectory` comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) were missing tests for edge cases where the `left`, `right`, or both operands were `null`.
📊 **Coverage:** Added comprehensive test methods in `HDLG.Tests/HdlgDirectoryTests.cs` to test all null permutations (`null` left, `null` right, both `null`) for all 6 comparison operators, bypassing `CS8625` safely using `((HdlgDirectory?)null)`.
✨ **Result:** Test coverage for `HdlgDirectory` comparison operators is now significantly increased, catching potential `NullReferenceException` flaws and proving the robust handling of null operands in relational evaluations.

---
*PR created automatically by Jules for task [11738626556021604163](https://jules.google.com/task/11738626556021604163) started by @bestter*