### PR TITLE
⚡ Bolt: Remove ToArray allocations in TreeView expansion

### DIFF
--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -128,8 +128,9 @@ namespace HDLG_winforms
 					}).ConfigureAwait(true);
 
 					// Safe WinForms practice: construct TreeNodes on the UI thread after I/O is complete
-					var dirNodes = new List<TreeNode>( );
-					var fileNodes = new List<TreeNode>( );
+					// Performance optimization: allocate fixed-size arrays instead of List<T> to avoid ToArray() allocation overhead.
+					var dirNodes = new TreeNode[dirInfos.Count];
+					var fileNodes = new TreeNode[fileInfos.Count];
 
 					for (int i = 0; i < dirInfos.Count; i++)
 					{
@@ -137,7 +138,7 @@ namespace HDLG_winforms
 						var node = new TreeNode( dir.Name );
 						node.Tag = new NodeInfo { IsDirectory = true, Path = dir.FullName };
 						node.Nodes.Add( new TreeNode( "Loading..." ) );
-						dirNodes.Add( node );
+						dirNodes[i] = node;
 					}
 
 					for (int i = 0; i < fileInfos.Count; i++)
@@ -145,12 +146,12 @@ namespace HDLG_winforms
 						var file = fileInfos[i];
 						var node = new TreeNode( file.Name );
 						node.Tag = new NodeInfo { IsDirectory = false, Path = file.FullName };
-						fileNodes.Add( node );
+						fileNodes[i] = node;
 					}
 
                     e.Node.TreeView?.BeginUpdate();
-                    e.Node.Nodes.AddRange(dirNodes.ToArray());
-                    e.Node.Nodes.AddRange(fileNodes.ToArray());
+                    e.Node.Nodes.AddRange(dirNodes);
+                    e.Node.Nodes.AddRange(fileNodes);
                     e.Node.TreeView?.EndUpdate();
                 }
                 catch (UnauthorizedAccessException ex)


### PR DESCRIPTION
💡 **What:** Replaced `List<TreeNode>` with fixed-size arrays (`TreeNode[]`) in `HDLG winforms/BrowserForm.cs` when constructing nodes for directories and files during tree view expansion.

🎯 **Why:** `TreeNodeCollection.AddRange()` accepts an array, and passing it a `List` via `.ToArray()` forces an unnecessary O(N) array allocation. By allocating the array directly with the known sizes (`dirInfos.Count` and `fileInfos.Count`), we avoid this redundant GC allocation altogether.

📊 **Impact:** Reduces GC overhead and eliminates redundant array allocation when a user expands a directory in the `BrowserForm` tree view, particularly noticeable for large directories with hundreds of files.

🔬 **Measurement:** Expanding very large directories will generate less short-lived garbage, which can be observed via .NET memory profiling.

---
*PR created automatically by Jules for task [17173337839241901690](https://jules.google.com/task/17173337839241901690) started by @bestter*