### PR TITLE
⚡ Bolt: Batch WinForms ListView Item additions

### DIFF
--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -219,13 +219,15 @@ namespace HDLG_winforms
 				listViewProperties.BeginUpdate();
 				try
 				{
-					AddPropertyToListView( "Name", fileInfo.Name );
-					AddPropertyToListView( "Path", fileInfo.FullName );
-					AddPropertyToListView( "Extension", fileInfo.Extension );
-					AddPropertyToListView( "Size (bytes)", fileInfo.Length.ToString( CultureInfo.CurrentCulture ) );
-					AddPropertyToListView( "Creation Time", fileInfo.CreationTime.ToString( "g", CultureInfo.CurrentCulture ) );
-					AddPropertyToListView( "Last Access Time", fileInfo.LastAccessTime.ToString( "g", CultureInfo.CurrentCulture ) );
-					AddPropertyToListView( "Last Write Time", fileInfo.LastWriteTime.ToString( "g", CultureInfo.CurrentCulture ) );
+					var items = new ListViewItem[7];
+					items[0] = CreateListViewItem( "Name", fileInfo.Name );
+					items[1] = CreateListViewItem( "Path", fileInfo.FullName );
+					items[2] = CreateListViewItem( "Extension", fileInfo.Extension );
+					items[3] = CreateListViewItem( "Size (bytes)", fileInfo.Length.ToString( CultureInfo.CurrentCulture ) );
+					items[4] = CreateListViewItem( "Creation Time", fileInfo.CreationTime.ToString( "g", CultureInfo.CurrentCulture ) );
+					items[5] = CreateListViewItem( "Last Access Time", fileInfo.LastAccessTime.ToString( "g", CultureInfo.CurrentCulture ) );
+					items[6] = CreateListViewItem( "Last Write Time", fileInfo.LastWriteTime.ToString( "g", CultureInfo.CurrentCulture ) );
+					listViewProperties.Items.AddRange( items );
 				}
 				finally
 				{
@@ -248,17 +250,23 @@ namespace HDLG_winforms
                         // the foreach loop to use the struct-based enumerator, preventing interface boxing allocations.
                         if (props is Dictionary<string, IConvertible> propsDict)
                         {
+                            var items = new ListViewItem[propsDict.Count];
+                            int i = 0;
                             foreach (var kvp in propsDict)
                             {
-                                AddPropertyToListView(kvp.Key, kvp.Value?.ToString() ?? "");
+                                items[i++] = CreateListViewItem(kvp.Key, kvp.Value?.ToString() ?? "");
                             }
+                            listViewProperties.Items.AddRange(items);
                         }
                         else
                         {
+                            var items = new ListViewItem[props.Count];
+                            int i = 0;
                             foreach (var kvp in props)
                             {
-                                AddPropertyToListView(kvp.Key, kvp.Value?.ToString() ?? "");
+                                items[i++] = CreateListViewItem(kvp.Key, kvp.Value?.ToString() ?? "");
                             }
+                            listViewProperties.Items.AddRange(items);
                         }
                     }
                     finally
@@ -310,11 +318,16 @@ namespace HDLG_winforms
             }
         }
 
-		private void AddPropertyToListView (string name, string value)
+		private static ListViewItem CreateListViewItem (string name, string value)
 		{
 			var item = new ListViewItem( name );
 			item.SubItems.Add( value );
-			listViewProperties.Items.Add( item );
+			return item;
+		}
+
+		private void AddPropertyToListView (string name, string value)
+		{
+			listViewProperties.Items.Add( CreateListViewItem( name, value ) );
 		}
 
 		private void BtnOpenFile_Click (object sender, EventArgs e)

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,10 +1,5 @@
-⚡ Optimize HTML encoding in DirectoryBrowser
+⚡ Bolt: Batch WinForms ListView Item additions
 
-💡 What:
-Introduced a `Dictionary<string, string>` cache in `DirectoryBrowser` to store the HTML-encoded strings of file property keys (e.g., 'Width', 'Height', 'CameraModel'). When `SaveHtmlAsync` is called and properties are looped over, it will now check the cache first before performing `WebUtility.HtmlEncode`.
-
-🎯 Why:
-File property keys are highly repetitive within a directory. Calling `WebUtility.HtmlEncode` inside nested loops for each file and every property incurs unnecessary CPU cycles and memory allocations for generating new strings. Caching the encoded strings prevents redundant work and improves the HTML report generation performance.
-
-📊 Measured Improvement:
-A benchmark comparing the original approach (encoding on every iteration) vs. the cached approach showed an execution time improvement of ~4% per operation (`~204.0us` vs `~195.6us`), confirming the net positive performance impact while producing identical HTML output.
+💡 What: Refactored `BrowserForm.cs` to use `ListView.Items.AddRange(ListViewItem[])` instead of calling `ListView.Items.Add(ListViewItem)` repeatedly inside loops. Extracted item creation to a static helper method.
+🎯 Why: Adding items sequentially to a `ListView` control causes overhead from internal collections management even when wrapped in `BeginUpdate`/`EndUpdate`. Batching the addition operations using an array reduces bounds checks, resizing overhead, and structural notifications, which is a highly recommended WinForms best practice for fast UI population.
+📊 Measured Improvement: Due to environment limitations on the agent (running .NET Core WinForms on Linux where the visual target `Microsoft.WindowsDesktop.App` cannot be instantiated or fully profiled), a live benchmark could not be collected. However, caching property results into arrays before passing to `AddRange` is a universally accepted WinForms optimization that reliably reduces large UI list population time by eliminating sequential .Add() overhead.


### PR DESCRIPTION
💡 What: Refactored `BrowserForm.cs` to use `ListView.Items.AddRange(ListViewItem[])` instead of calling `ListView.Items.Add(ListViewItem)` repeatedly inside loops. Extracted item creation to a static helper method.
🎯 Why: Adding items sequentially to a `ListView` control causes overhead from internal collections management even when wrapped in `BeginUpdate`/`EndUpdate`. Batching the addition operations using an array reduces bounds checks, resizing overhead, and structural notifications, which is a highly recommended WinForms best practice for fast UI population.
📊 Measured Improvement: Due to environment limitations on the agent (running .NET Core WinForms on Linux where the visual target `Microsoft.WindowsDesktop.App` cannot be instantiated or fully profiled), a live benchmark could not be collected. However, caching property results into arrays before passing to `AddRange` is a universally accepted WinForms optimization that reliably reduces large UI list population time by eliminating sequential .Add() overhead.

---
*PR created automatically by Jules for task [4882719714690410316](https://jules.google.com/task/4882719714690410316) started by @bestter*