### PR TITLE
🛡️ Sentinel: [Low] Fix Improper URL Encoding for File Path

### DIFF
--- a/HDLG winforms/DirectoryBrowser.cs
+++ b/HDLG winforms/DirectoryBrowser.cs
@@ -526,7 +526,7 @@ namespace HDLG_winforms
 			await writer.WriteLineAsync( spacer + "<div class=\"file\">" ).ConfigureAwait( false );
 
 			string encodedName = WebUtility.HtmlEncode( file.Name );
-			string encodedPath = WebUtility.HtmlEncode( file.Path );
+			string encodedPath = Uri.EscapeDataString( file.Path );
 			await writer.WriteLineAsync( $"{spacer}\t<a href=\"file:///{encodedPath}\" download=\"{encodedName}\" referrerpolicy=\"strict-origin\">{encodedName}</a>" ).ConfigureAwait( false );
 
 			await writer.WriteLineAsync( $"{spacer}\t<div class=\"file-meta\">" ).ConfigureAwait( false );


### PR DESCRIPTION
🎯 **What:** Fixed an issue where local file paths in HTML `href` attributes were improperly encoded using `WebUtility.HtmlEncode` instead of `Uri.EscapeDataString`.

⚠️ **Risk:** If a file path contains characters with special meaning in URLs (such as `#` or `?`), the browser will misinterpret the URL. For example, a file named `file #1.txt` would be interpreted as a request for `file.txt` with a fragment identifier of `#1`, resulting in broken links and preventing users from opening the exported files.

🛡️ **Solution:** Replaced `WebUtility.HtmlEncode( file.Path )` with `Uri.EscapeDataString( file.Path )` for the `href` attribute generation in `DirectoryBrowser.cs:529`, correctly encoding the path for URL contexts while preserving other HTML encodings for attributes like `download` and the link text.

---
*PR created automatically by Jules for task [6371797601581930235](https://jules.google.com/task/6371797601581930235) started by @bestter*