### PR TITLE
🧪 [testing improvement] Add test for IOException in BrowserForm LoadDirectoryData

### DIFF
--- a/HDLG winforms/BrowserForm.cs
+++ b/HDLG winforms/BrowserForm.cs
@@ -23,10 +23,12 @@ namespace HDLG_winforms
 		private readonly string _resolvedRootDirectoryWithSeparator;
 		private readonly FilePropertyBrowser propertyBrowser;
 		private readonly ILogger logger;
+		private readonly Action<string>? _showError;
 
-		public BrowserForm (string rootDirectory, FilePropertyBrowser propertyBrowser, ILogger logger)
+		public BrowserForm (string rootDirectory, FilePropertyBrowser propertyBrowser, ILogger logger, Action<string>? showError = null)
 		{
 			InitializeComponent( );
+			_showError = showError;
 			Icon = AppBranding.LoadApplicationIcon();
 			AppUiBootstrap.RemoveFormBranding(this);
 			this.rootDirectory = rootDirectory;
@@ -54,7 +56,8 @@ namespace HDLG_winforms
 			catch (IOException ex)
 			{
 				logger.Error(ex, "IO Error loading root directory in BrowserForm");
-                MessageBox.Show(this, "An IO error occurred while loading the directory.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+				if (_showError != null) _showError("An IO error occurred while loading the directory.");
+				else MessageBox.Show(this, "An IO error occurred while loading the directory.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 			catch (Exception ex)
 			{

--- a/HDLG.Tests/BrowserFormLoadTests.cs
+++ b/HDLG.Tests/BrowserFormLoadTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using HdlgFileProperty;
+using HDLG_winforms;
+using Krypton.Toolkit;
+using Moq;
+using Serilog;
+using System.Reflection;
+using System.Windows.Forms;
+using System.IO;
+using System;
+
+namespace HDLG.Tests
+{
+    [Collection(nameof(WinFormsUiTestCollection))]
+    public class BrowserFormLoadTests
+    {
+        private static void RunSta(Action action)
+        {
+            Exception? caught = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    caught = ex;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (caught != null)
+            {
+                throw caught;
+            }
+        }
+
+        [Fact]
+        public void BrowserForm_Load_CatchesIOException_And_ShowsMessage()
+        {
+            RunSta(() =>
+            {
+                AppUiBootstrap.Configure();
+                string tempDir = Path.Combine(Path.GetTempPath(), "HDLG_UiTests_BrowserFormThrows_" + Guid.NewGuid());
+                System.IO.Directory.CreateDirectory(tempDir);
+                try
+                {
+                    var mockLogger = new Mock<ILogger>();
+                    bool errorLogged = false;
+                    mockLogger.Setup(x => x.Error(It.IsAny<IOException>(), "IO Error loading root directory in BrowserForm"))
+                              .Callback(() => errorLogged = true);
+
+                    var propBrowser = new FilePropertyBrowser(mockLogger.Object, new ImagePropertyGetter());
+
+                    bool messageShown = false;
+                    string shownMessage = string.Empty;
+                    Action<string> showError = (msg) =>
+                    {
+                        messageShown = true;
+                        shownMessage = msg;
+                    };
+
+                    using var form = new BrowserForm(tempDir, propBrowser, mockLogger.Object, showError);
+
+                    var treeViewField = form.GetType().GetField("treeView1", BindingFlags.Instance | BindingFlags.NonPublic);
+                    var treeView = (KryptonTreeView)treeViewField!.GetValue(form)!;
+
+                    treeView.BeforeExpand += (s, e) =>
+                    {
+                        throw new IOException("Simulated IO failure");
+                    };
+
+                    var loadMethod = form.GetType().GetMethod("BrowserForm_Load", BindingFlags.Instance | BindingFlags.NonPublic);
+
+                    loadMethod!.Invoke(form, new object[] { form, EventArgs.Empty });
+
+                    errorLogged.Should().BeTrue();
+                    messageShown.Should().BeTrue();
+                    shownMessage.Should().Be("An IO error occurred while loading the directory.");
+                }
+                finally
+                {
+                    if (System.IO.Directory.Exists(tempDir))
+                    {
+                        System.IO.Directory.Delete(tempDir, true);
+                    }
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Addresses untested IOException block in BrowserForm_Load (now extracted to LoadDirectoryData) that logs and shows an error message.
📊 **Coverage:** Added BrowserFormLoadTests to verify the exception is correctly caught, logged, and an error message is dispatched.
✨ **Result:** Increased test coverage for UI exception handling by injecting an optional showError delegate to prevent UI thread blocking during automated testing.

---
*PR created automatically by Jules for task [13135551502316554532](https://jules.google.com/task/13135551502316554532) started by @bestter*