### PR TITLE
🧪 Add tests for PerformanceCount struct

### DIFF
--- a/HDLG winforms/HDLG winforms.csproj
+++ b/HDLG winforms/HDLG winforms.csproj
@@ -59,6 +59,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="HDLG.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="hdlg.css" />
   </ItemGroup>
 

--- a/HDLG.Tests/PerformanceCountTests.cs
+++ b/HDLG.Tests/PerformanceCountTests.cs
@@ -1,0 +1,44 @@
+using System;
+using FluentAssertions;
+using HDLG_winforms;
+using Xunit;
+
+namespace HDLG.Tests
+{
+    public class PerformanceCountTests
+    {
+        [Fact]
+        public void Empty_ReturnsPerformanceCountWithMinValueTimeSpans()
+        {
+            // Act
+            var empty = PerformanceCount.Empty;
+
+            // Assert
+            empty.BrowseTime.Should().Be(TimeSpan.MinValue);
+            empty.SaveTime.Should().Be(TimeSpan.MinValue);
+            empty.TotalTime.Should().Be(TimeSpan.MinValue);
+        }
+
+        [Fact]
+        public void FieldAssignments_PersistCorrectly()
+        {
+            // Arrange
+            var browseTime = TimeSpan.FromSeconds(1);
+            var saveTime = TimeSpan.FromSeconds(2);
+            var totalTime = TimeSpan.FromSeconds(3);
+
+            // Act
+            var perfCount = new PerformanceCount
+            {
+                BrowseTime = browseTime,
+                SaveTime = saveTime,
+                TotalTime = totalTime
+            };
+
+            // Assert
+            perfCount.BrowseTime.Should().Be(browseTime);
+            perfCount.SaveTime.Should().Be(saveTime);
+            perfCount.TotalTime.Should().Be(totalTime);
+        }
+    }
+}

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,3 @@
+🎯 **What:** The `PerformanceCount` struct lacked test coverage. Added `InternalsVisibleTo` to the main project and explicit unit tests to the `HDLG.Tests` project.
+📊 **Coverage:** Tested the static `Empty` instance (ensuring all properties are `TimeSpan.MinValue`) and normal field assignments (`BrowseTime`, `SaveTime`, `TotalTime`).
+✨ **Result:** Ensured the correct behavior and default states of the struct, improving overall test coverage and code reliability.


### PR DESCRIPTION
🎯 **What:** The `PerformanceCount` struct lacked test coverage. Added `InternalsVisibleTo` to the main project and explicit unit tests to the `HDLG.Tests` project.
📊 **Coverage:** Tested the static `Empty` instance (ensuring all properties are `TimeSpan.MinValue`) and normal field assignments (`BrowseTime`, `SaveTime`, `TotalTime`).
✨ **Result:** Ensured the correct behavior and default states of the struct, improving overall test coverage and code reliability.

---
*PR created automatically by Jules for task [14969951217610580911](https://jules.google.com/task/14969951217610580911) started by @bestter*