### PR TITLE
🛡️ Sentinel: [security improvement] Fail securely on fatal background thread exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -112,3 +112,8 @@
 **Vulnerability:** Generated HTML exports of local directories lacked a `Referrer-Policy` header. If a user clicks an external link in the report (like the "Root directory icons" credit link), or if an external resource is loaded, the browser might send the full local file path (e.g., `file:///C:/Users/name/Documents/export.html`) in the HTTP `Referer` header to the external site, causing an information disclosure.
 **Learning:** Local file pathways must be protected from leakage to external domains when generating HTML files meant to be opened locally.
 **Prevention:** Always add `<meta name="referrer" content="no-referrer">` to HTML head sections generated for local offline viewing.
+
+## 2024-07-28 - Implement Fail Securely Principle for Background Threads
+**Vulnerability:** The application was vulnerable to continuing execution in an undefined or corrupted state because the global background exception handler (`CurrentDomain_UnhandledException` in `Program.cs`) caught fatal exceptions, logged them, but did not terminate the application.
+**Learning:** When unhandled exceptions occur on background threads, the application memory state may be corrupted. Allowing it to continue running violates the "fail securely" principle and can lead to unexpected behaviors, data corruption, or security bypasses.
+**Prevention:** In global error handlers for background threads (`AppDomain.CurrentDomain.UnhandledException`), always securely terminate the process (e.g., using `Environment.Exit(1)`) after logging the error and notifying the user.

--- a/HDLG winforms/Program.cs
+++ b/HDLG winforms/Program.cs
@@ -100,7 +100,7 @@ namespace HDLG_winforms
 
 			// Souvent, pour les erreurs de thread d'arrière-plan, il est plus sûr de fermer l'application
 			// car l'état de la mémoire peut être corrompu.
-			// Application.Exit();
+			Environment.Exit(1);
 		}
 
 		// Fonction utilitaire pour éviter de répéter le code de la boîte de dialogue


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application was vulnerable to continuing execution in an undefined or corrupted state. The global background exception handler (`CurrentDomain_UnhandledException` in `Program.cs`) caught fatal exceptions, logged them, and presented an error message, but did not terminate the application.
🎯 **Impact:** When unhandled exceptions occur on background threads, the application memory state may be corrupted. Allowing the application to continue running violates the "fail securely" principle and can lead to unexpected behaviors, data corruption, or potential security bypasses if security-critical variables are left in an invalid state.
🔧 **Fix:** Modified `CurrentDomain_UnhandledException` in `Program.cs` to call `Environment.Exit(1)` after logging the error and displaying the generic error message to the user, ensuring the process is forcefully and securely terminated.
✅ **Verification:** Verified that the code cleanly terminates the application via `Environment.Exit(1)` after logging. Ran the test suite to ensure the build compiles correctly without regressions.

---
*PR created automatically by Jules for task [5724786331528484170](https://jules.google.com/task/5724786331528484170) started by @bestter*