### PR TITLE
🛡️ Sentinel: [HIGH] Enforce Fail Securely on unhandled background exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -112,3 +112,8 @@
 **Vulnerability:** Generated HTML exports of local directories lacked a `Referrer-Policy` header. If a user clicks an external link in the report (like the "Root directory icons" credit link), or if an external resource is loaded, the browser might send the full local file path (e.g., `file:///C:/Users/name/Documents/export.html`) in the HTTP `Referer` header to the external site, causing an information disclosure.
 **Learning:** Local file pathways must be protected from leakage to external domains when generating HTML files meant to be opened locally.
 **Prevention:** Always add `<meta name="referrer" content="no-referrer">` to HTML head sections generated for local offline viewing.
+
+## 2024-05-25 - [Fail-Open Background Thread Exception]
+**Vulnerability:** The application caught `AppDomain.CurrentDomain.UnhandledException` for background threads but merely logged the error and displayed a MessageBox without calling `Environment.Exit`, allowing the process to continue running in a corrupted state.
+**Learning:** If a critical background exception occurs, the application state is likely corrupted. Allowing the process to continue running violates the 'Fail Securely' principle and could lead to unpredictable security or logic failures down the line.
+**Prevention:** In global error handlers for background threads, always enforce the 'Fail Securely' principle by gracefully but forcefully terminating the process (e.g., using `Environment.Exit(1)`).

--- a/HDLG winforms/Program.cs
+++ b/HDLG winforms/Program.cs
@@ -100,7 +100,7 @@ namespace HDLG_winforms
 
 			// Souvent, pour les erreurs de thread d'arrière-plan, il est plus sûr de fermer l'application
 			// car l'état de la mémoire peut être corrompu.
-			// Application.Exit();
+			Environment.Exit( 1 );
 		}
 
 		// Fonction utilitaire pour éviter de répéter le code de la boîte de dialogue


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application caught background thread exceptions via `AppDomain.CurrentDomain.UnhandledException` but failed to terminate the process (the exit code was commented out), allowing it to continue running.
🎯 **Impact:** If a fatal exception occurs in a background thread, the internal memory state or business logic might become corrupted. Continuing execution in a corrupted state is a violation of the 'Fail Securely' principle and can lead to unpredictable behavior, data corruption, or security bypasses.
🔧 **Fix:** Replaced the commented-out `Application.Exit();` with `Environment.Exit(1);` to forcefully terminate the process when a fatal background thread error is intercepted.
✅ **Verification:** Verified by checking `Program.cs` and running unit tests to ensure no regressions. The change cleanly ensures the process fails securely.

---
*PR created automatically by Jules for task [3469293193700741998](https://jules.google.com/task/3469293193700741998) started by @bestter*